### PR TITLE
Fix AppUpdates success count handling

### DIFF
--- a/modules/08_AppUpdates/AppUpdates.psm1
+++ b/modules/08_AppUpdates/AppUpdates.psm1
@@ -272,7 +272,8 @@ function Invoke-FakeUpdateOnFiles {
     Write-Warn $msg
   }
 
-  return ($results | Where-Object { $_.Success }).Count
+  $successes = @($results | Where-Object { $_.Success })
+  return $successes.Count
 }
 
 function Test-Ready { param($Context) return $true }


### PR DESCRIPTION
## Summary
- ensure AppUpdates success counting wraps results in an array before taking Count
- prevent failures when only a single executable is processed by update_single

## Testing
- not run (PowerShell environment not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68cf89d4ee7c8333bfc772ba66f79c01