### PR TITLE
Fix interactive module selection array handling

### DIFF
--- a/core/CpCore.psm1
+++ b/core/CpCore.psm1
@@ -87,7 +87,9 @@ function __CP_GetModules {
 function __CP_SelectModules {
   param([object[]]$Modules, [string[]]$Include, [string[]]$Exclude)
   $Modules = @($Modules)
-  if ($Include -and $Include.Count -gt 0) {
+  if ($Include) { $Include = @($Include) } else { $Include = @() }
+  if ($Exclude) { $Exclude = @($Exclude) } else { $Exclude = @() }
+  if ($Include.Count -gt 0) {
     $wanted = @()
     foreach ($pat in $Include) {
       $rx = [regex]::Escape($pat).Replace('\*','.*').Replace('\?','.')
@@ -95,7 +97,7 @@ function __CP_SelectModules {
     }
     $Modules = @($wanted | Select-Object -Unique)
   }
-  if ($Exclude -and $Exclude.Count -gt 0) {
+  if ($Exclude.Count -gt 0) {
     foreach ($pat in $Exclude) {
       $rx = [regex]::Escape($pat).Replace('\*','.*').Replace('\?','.')
       $Modules = @($Modules | Where-Object { $_.Name -notmatch $rx -and $_.Category -notmatch $rx })

--- a/core/Engine.psm1
+++ b/core/Engine.psm1
@@ -83,7 +83,9 @@ function Get-Modules {
 
 function Select-ModulesByName {
   param([object[]]$Modules, [string[]]$Include, [string[]]$Exclude)
-  if ($Include -and $Include.Count -gt 0) {
+  if ($Include) { $Include = @($Include) } else { $Include = @() }
+  if ($Exclude) { $Exclude = @($Exclude) } else { $Exclude = @() }
+  if ($Include.Count -gt 0) {
     $wanted = @()
     foreach ($pat in $Include) {
       $rx = [regex]::Escape($pat).Replace('\*','.*').Replace('\?','.')
@@ -91,7 +93,7 @@ function Select-ModulesByName {
     }
     $Modules = $wanted | Select-Object -Unique
   }
-  if ($Exclude -and $Exclude.Count -gt 0) {
+  if ($Exclude.Count -gt 0) {
     foreach ($pat in $Exclude) {
       $rx = [regex]::Escape($pat).Replace('\*','.*').Replace('\?','.')
       $Modules = $Modules | Where-Object { $_.Name -notmatch $rx -and $_.Category -notmatch $rx }


### PR DESCRIPTION
## Summary
- normalize Include/Exclude parameters so they are always treated as arrays
- prevent interactive module selection from failing when a single module name is provided
- mirror the same fix in the legacy engine helper for consistency

## Testing
- not run (PowerShell is unavailable in the container environment)


------
https://chatgpt.com/codex/tasks/task_e_68d32ec9631083338e1200e99054ca4c