### PR TITLE
Implement AI-assisted malware persistence triage

### DIFF
--- a/modules/11_MalwarePersistence/MalwarePersistence.psm1
+++ b/modules/11_MalwarePersistence/MalwarePersistence.psm1
@@ -1,6 +1,5 @@
 Set-StrictMode -Version Latest
 
-# Import required modules if not already loaded
 if (-not (Get-Command New-ModuleResult -EA SilentlyContinue)) {
   Import-Module -Force -DisableNameChecking (Join-Path $PSScriptRoot '../../core/Contracts.psm1')
 }
@@ -8,8 +7,846 @@ if (-not (Get-Command Write-Info -EA SilentlyContinue)) {
   Import-Module -Force -DisableNameChecking (Join-Path $PSScriptRoot '../../core/Utils.psm1')
 }
 
-function Test-Ready { param($Context) return $true }
-function Invoke-Verify { param($Context) return (New-ModuleResult -Name 'MalwarePersistence' -Status 'Succeeded' -Message 'Verified (stub)') }
-function Invoke-Apply  { param($Context) return (New-ModuleResult -Name 'MalwarePersistence' -Status 'Succeeded' -Message 'Applied (stub)') }
+$script:ModuleName              = 'MalwarePersistence'
+$script:ApiUrl                  = 'https://openrouter.ai/api/v1/chat/completions'
+$script:ApiKeyEnvVar            = 'OPENROUTER_API_KEY'
+$script:AiModel                 = 'openai/gpt-5'
+$script:RecentDaysThreshold     = 14
+$script:MaxTaskEntries          = 25
+$script:MaxProcessEntries       = 25
+$script:MaxScriptEntries        = 25
+$script:SnippetLineCount        = 40
+$script:InterpreterNames        = @('powershell.exe','pwsh.exe','cmd.exe','wscript.exe','cscript.exe','mshta.exe','python.exe','rundll32.exe','regsvr32.exe')
+$script:SuspiciousPathPrefixes  = @('c:\\users\\', 'c:\\programdata\\', 'c:\\public\\', 'c:\\inetpub\\', 'c:\\windows\\temp\\')
+$script:SuspiciousPathKeywords  = @('\\downloads\\', '\\appdata\\', '\\temp\\')
+$script:SuspiciousCommandFlags  = @(
+  @{ Pattern = '(?i)-(enc|encodedcommand)'; Flag = 'EncodedCommand' },
+  @{ Pattern = '(?i)\b(-|/)(e|ec|exec|l|lv|lvp)\b'; Flag = 'ShellSwitch' },
+  @{ Pattern = '(?i)\bno(p|profile)\b'; Flag = 'NoProfile' },
+  @{ Pattern = '(?i)hidden'; Flag = 'HiddenWindow' },
+  @{ Pattern = '(?i)mimikatz|sekurlsa'; Flag = 'CredentialTheft' },
+  @{ Pattern = '(?i)ntdsutil|ntds\.dit'; Flag = 'NTDS' },
+  @{ Pattern = '(?i)reverse\s*tcp|bind\s*shell'; Flag = 'ReverseShell' }
+)
+$script:ScriptExtensions        = @('.ps1','.psm1','.bat','.cmd','.vbs','.js','.jse','.hta','.py')
+$script:AccessibilityBinaries   = @('sethc.exe','utilman.exe','osk.exe')
+
+function Get-OpenRouterApiKey {
+  $key = [System.Environment]::GetEnvironmentVariable($script:ApiKeyEnvVar)
+  if (-not $key) { return '' }
+  return $key
+}
+
+function Normalize-Path {
+  param([string]$Path)
+  if ([string]::IsNullOrWhiteSpace($Path)) { return '' }
+  $normalized = $Path -replace '[\\/]+', '\\'
+  $normalized = $normalized.Trim()
+  return $normalized
+}
+
+function Test-IsSuspiciousPath {
+  param([string]$Path)
+  $normalized = Normalize-Path -Path $Path
+  if (-not $normalized) { return $false }
+  $lower = $normalized.ToLowerInvariant()
+  foreach ($prefix in $script:SuspiciousPathPrefixes) {
+    if ($lower.StartsWith($prefix)) { return $true }
+  }
+  foreach ($keyword in $script:SuspiciousPathKeywords) {
+    if ($lower.Contains($keyword)) { return $true }
+  }
+  return $false
+}
+
+function Test-IsRecentDirectory {
+  param([string]$Path)
+  if (-not $Path) { return $false }
+  try {
+    $directory = Split-Path -Path $Path -Parent
+    if (-not $directory) { return $false }
+    if (-not (Test-Path -LiteralPath $directory)) { return $false }
+    $dirInfo = Get-Item -LiteralPath $directory -ErrorAction Stop
+    $age = (Get-Date) - $dirInfo.CreationTime
+    return ($age.TotalDays -le $script:RecentDaysThreshold)
+  } catch {
+    return $false
+  }
+}
+
+function Get-CommandFlags {
+  param([string]$CommandLine)
+  $flags = New-Object 'System.Collections.Generic.List[string]'
+  if (-not $CommandLine) { return $flags }
+  foreach ($entry in $script:SuspiciousCommandFlags) {
+    if ($CommandLine -match $entry.Pattern) {
+      $flags.Add($entry.Flag) | Out-Null
+    }
+  }
+  return $flags
+}
+
+function Test-IsInterpreterUsage {
+  param(
+    [string]$Executable,
+    [string]$CommandLine
+  )
+  $exeName = ''
+  try {
+    if ($Executable) { $exeName = [System.IO.Path]::GetFileName($Executable) }
+  } catch {
+    $exeName = ''
+  }
+  if ($exeName -and ($script:InterpreterNames -contains $exeName.ToLowerInvariant())) {
+    return $true
+  }
+  if ($CommandLine -and ($CommandLine -match '(?i)\b(powershell|pwsh|cmd|wscript|cscript|mshta|python|rundll32|regsvr32)\b')) {
+    return $true
+  }
+  return $false
+}
+
+function Convert-TriggerSummary {
+  param($Triggers)
+  if (-not $Triggers) { return '' }
+  $items = New-Object 'System.Collections.Generic.List[string]'
+  foreach ($trigger in $Triggers) {
+    try {
+      $text = $trigger.ToString()
+      if ($text) { $items.Add($text.Trim()) | Out-Null }
+    } catch {
+      continue
+    }
+  }
+  return ($items -join '; ')
+}
+
+function Get-TaskCandidates {
+  $tasks = @()
+  try {
+    $tasks = Get-ScheduledTask -ErrorAction Stop
+  } catch {
+    Write-Warn ("Failed to enumerate scheduled tasks: {0}" -f $_.Exception.Message)
+    return @()
+  }
+
+  $results = New-Object 'System.Collections.Generic.List[object]'
+  foreach ($task in $tasks) {
+    if (-not $task.Actions) { continue }
+    foreach ($action in $task.Actions) {
+      $execute = $null
+      $arguments = $null
+      try {
+        $execute = $action.Execute
+        $arguments = $action.Arguments
+      } catch {
+        continue
+      }
+      $commandLine = if ($arguments) { "`"$execute`" $arguments" } else { "`"$execute`"" }
+      $isSuspiciousPath = Test-IsSuspiciousPath -Path $execute
+      $flags = Get-CommandFlags -CommandLine $commandLine
+      $isInterpreter = Test-IsInterpreterUsage -Executable $execute -CommandLine $commandLine
+      $isRecentFolder = Test-IsRecentDirectory -Path $execute
+      $registrationDate = $null
+      $registrationFlag = $false
+      try {
+        $rawDate = $task.RegistrationInfo.Date
+        if ($rawDate) {
+          if ([DateTime]::TryParse($rawDate, [ref]$registrationDate)) {
+            if (((Get-Date) - $registrationDate).TotalDays -le $script:RecentDaysThreshold) {
+              $registrationFlag = $true
+            }
+          }
+        }
+      } catch {
+        $registrationDate = $null
+      }
+
+      if (-not ($isSuspiciousPath -or $isInterpreter -or $registrationFlag -or $isRecentFolder)) {
+        continue
+      }
+
+      $flagSet = New-Object 'System.Collections.Generic.List[string]'
+      if ($isSuspiciousPath) { $flagSet.Add('SuspiciousPath') | Out-Null }
+      if ($isInterpreter) { $flagSet.Add('InterpreterLaunch') | Out-Null }
+      foreach ($flag in $flags) { if ($flag) { $flagSet.Add($flag) | Out-Null } }
+      if ($isRecentFolder) { $flagSet.Add('RecentFolder') | Out-Null }
+      if ($registrationFlag) { $flagSet.Add('RecentlyRegistered') | Out-Null }
+      if ($task.Principal -and $task.Principal.RunLevel -eq 'Highest') { $flagSet.Add('RunsHighestPrivileges') | Out-Null }
+
+      $triggerSummary = Convert-TriggerSummary -Triggers $task.Triggers
+      $results.Add([pscustomobject]@{
+        Type             = 'Task'
+        Name             = $task.TaskName
+        TaskPath         = $task.TaskPath
+        FullName         = ("{0}{1}" -f $task.TaskPath, $task.TaskName)
+        ActionPath       = $execute
+        Arguments        = $arguments
+        RunAsUser        = $task.Principal.UserId
+        TriggerSummary   = $triggerSummary
+        RegistrationDate = $registrationDate
+        Flags            = $flagSet.ToArray()
+        CommandLine      = $commandLine
+      }) | Out-Null
+    }
+  }
+
+  return @($results | Select-Object -First $script:MaxTaskEntries)
+}
+
+function Get-ProcessConnectionMap {
+  $map = @{}
+  try {
+    $connections = Get-NetTCPConnection -ErrorAction Stop
+  } catch {
+    return $map
+  }
+  foreach ($conn in $connections) {
+    $pid = $conn.OwningProcess
+    if (-not $pid) { continue }
+    if (-not $map.ContainsKey($pid)) {
+      $map[$pid] = [pscustomobject]@{
+        Listening   = New-Object 'System.Collections.Generic.List[string]'
+        Established = New-Object 'System.Collections.Generic.List[string]'
+      }
+    }
+    $entry = $map[$pid]
+    $representation = ''
+    try {
+      $local = "{0}:{1}" -f $conn.LocalAddress, $conn.LocalPort
+      $remote = if ($conn.RemoteAddress -and $conn.RemotePort) { "{0}:{1}" -f $conn.RemoteAddress, $conn.RemotePort } else { '' }
+      $representation = if ($remote) { "{0} -> {1} ({2})" -f $local, $remote, $conn.State } else { "{0} ({1})" -f $local, $conn.State }
+    } catch {
+      $representation = ''
+    }
+    if ($conn.State -eq 'Listen') {
+      if ($representation) { $entry.Listening.Add($representation) | Out-Null }
+    } elseif ($representation) {
+      $entry.Established.Add($representation) | Out-Null
+    }
+  }
+  return $map
+}
+
+function Get-SignatureStatus {
+  param([string]$Path)
+  if (-not $Path) { return 'Unknown' }
+  if (-not (Test-Path -LiteralPath $Path)) { return 'Missing' }
+  try {
+    $signature = Get-AuthenticodeSignature -FilePath $Path -ErrorAction Stop
+  } catch {
+    return 'Unknown'
+  }
+  if (-not $signature) { return 'Unknown' }
+  if ($signature.Status -eq 'Valid' -and $signature.SignerCertificate) {
+    $subject = $signature.SignerCertificate.Subject
+    if ($subject -and ($subject -match 'Microsoft')) { return 'Microsoft' }
+    return 'Signed'
+  }
+  if ($signature.Status -eq 'NotSigned') { return 'Unsigned' }
+  return $signature.Status.ToString()
+}
+
+function Get-ProcessCandidates {
+  $processes = @()
+  try {
+    $processes = Get-CimInstance -ClassName Win32_Process -ErrorAction Stop
+  } catch {
+    Write-Warn ("Failed to enumerate processes: {0}" -f $_.Exception.Message)
+    return @()
+  }
+
+  $connectionMap = Get-ProcessConnectionMap
+  $results = New-Object 'System.Collections.Generic.List[object]'
+  foreach ($proc in $processes) {
+    $path = $proc.ExecutablePath
+    $commandLine = $proc.CommandLine
+    $creationTime = $null
+    try {
+      if ($proc.CreationDate) { $creationTime = [System.Management.ManagementDateTimeConverter]::ToDateTime($proc.CreationDate) }
+    } catch {
+      $creationTime = $null
+    }
+    $isSuspiciousPath = Test-IsSuspiciousPath -Path $path
+    $isRecentDir = Test-IsRecentDirectory -Path $path
+    $flags = Get-CommandFlags -CommandLine $commandLine
+    $isInterpreter = Test-IsInterpreterUsage -Executable $path -CommandLine $commandLine
+    $connections = if ($connectionMap.ContainsKey($proc.ProcessId)) { $connectionMap[$proc.ProcessId] } else { $null }
+    $listening = @()
+    $established = @()
+    if ($connections) {
+      $listening = $connections.Listening.ToArray()
+      $established = $connections.Established.ToArray()
+    }
+    $shouldKeep = $isSuspiciousPath -or $isInterpreter -or $isRecentDir -or ($flags.Count -gt 0) -or ($listening.Count -gt 0)
+    if (-not $shouldKeep) { continue }
+
+    $flagSet = New-Object 'System.Collections.Generic.List[string]'
+    if ($isSuspiciousPath) { $flagSet.Add('SuspiciousPath') | Out-Null }
+    if ($isInterpreter) { $flagSet.Add('InterpreterProcess') | Out-Null }
+    foreach ($flag in $flags) { if ($flag) { $flagSet.Add($flag) | Out-Null } }
+    if ($isRecentDir) { $flagSet.Add('RecentFolder') | Out-Null }
+    if ($listening.Count -gt 0) { $flagSet.Add('ListeningPort') | Out-Null }
+
+    $signatureStatus = Get-SignatureStatus -Path $path
+
+    $results.Add([pscustomobject]@{
+      Type        = 'Process'
+      Name        = $proc.Name
+      ProcessId   = $proc.ProcessId
+      Path        = $path
+      CommandLine = $commandLine
+      StartTime   = $creationTime
+      Flags       = $flagSet.ToArray()
+      Signature   = $signatureStatus
+      Listening   = $listening
+      Connections = $established
+    }) | Out-Null
+  }
+
+  return @($results | Sort-Object { $_.StartTime } -Descending | Select-Object -First $script:MaxProcessEntries)
+}
+
+function Get-FileSnippet {
+  param(
+    [string]$Path,
+    [int]$LineCount
+  )
+  $head = ''
+  $tail = ''
+  try {
+    $headLines = Get-Content -LiteralPath $Path -TotalCount $LineCount -ErrorAction Stop
+    $head = ($headLines -join [Environment]::NewLine)
+  } catch {
+    $head = ''
+  }
+  try {
+    $tailLines = Get-Content -LiteralPath $Path -Tail $LineCount -ErrorAction Stop
+    $tail = ($tailLines -join [Environment]::NewLine)
+  } catch {
+    $tail = ''
+  }
+  if ($head.Length -gt 600) { $head = $head.Substring(0, 600) }
+  if ($tail.Length -gt 600) { $tail = $tail.Substring([Math]::Max(0, $tail.Length - 600)) }
+  return [pscustomobject]@{ Head = $head; Tail = $tail }
+}
+
+function Get-ScriptFlags {
+  param(
+    [string]$Path,
+    [string]$Head,
+    [string]$Tail
+  )
+  $flags = New-Object 'System.Collections.Generic.List[string]'
+  $combined = ($Head + ' ' + $Tail)
+  if ($combined -match '(?i)mimikatz') { $flags.Add('MentionsMimikatz') | Out-Null }
+  if ($combined -match '(?i)ntdsutil|ntds\.dit|esedbexport') { $flags.Add('MentionsNTDS') | Out-Null }
+  if ($combined -match '(?i)base64|frombase64string') { $flags.Add('Base64Reference') | Out-Null }
+  if ($combined -match '(?i)invoke-expression') { $flags.Add('InvokeExpression') | Out-Null }
+  if (Test-IsSuspiciousPath -Path $Path) { $flags.Add('SuspiciousPath') | Out-Null }
+  try {
+    $fileInfo = Get-Item -LiteralPath $Path -ErrorAction Stop
+    if (((Get-Date) - $fileInfo.CreationTime).TotalDays -le $script:RecentDaysThreshold) {
+      $flags.Add('RecentlyCreated') | Out-Null
+    }
+  } catch {
+    # ignore
+  }
+  return $flags
+}
+
+function Get-ScriptCandidates {
+  $roots = New-Object 'System.Collections.Generic.List[string]'
+  if ($env:USERPROFILE) { $roots.Add($env:USERPROFILE) | Out-Null }
+  if ($env:PUBLIC) { $roots.Add($env:PUBLIC) | Out-Null }
+  if ($env:ProgramData) { $roots.Add($env:ProgramData) | Out-Null }
+  if ($env:SystemDrive) { $roots.Add((Join-Path $env:SystemDrive 'inetpub')) | Out-Null }
+  if (Test-Path 'C:\Users') { $roots.Add('C:\Users') | Out-Null }
+
+  $results = New-Object 'System.Collections.Generic.List[object]'
+  foreach ($root in $roots) {
+    if (-not $root) { continue }
+    if (-not (Test-Path -LiteralPath $root)) { continue }
+    try {
+      $files = Get-ChildItem -LiteralPath $root -Recurse -File -ErrorAction Stop | Where-Object { $_.Extension -and ($script:ScriptExtensions -contains $_.Extension.ToLowerInvariant()) }
+    } catch {
+      Write-Warn ("Failed to scan scripts under {0}: {1}" -f $root, $_.Exception.Message)
+      continue
+    }
+    foreach ($file in $files) {
+      $snippet = Get-FileSnippet -Path $file.FullName -LineCount $script:SnippetLineCount
+      $flags = Get-ScriptFlags -Path $file.FullName -Head $snippet.Head -Tail $snippet.Tail
+      if ($flags.Count -eq 0) { continue }
+      $results.Add([pscustomobject]@{
+        Type     = 'Script'
+        Path     = $file.FullName
+        Created  = $file.CreationTime
+        Modified = $file.LastWriteTime
+        Flags    = $flags.ToArray()
+        Head     = $snippet.Head
+        Tail     = $snippet.Tail
+      }) | Out-Null
+    }
+  }
+
+  $unique = $results | Sort-Object Path -Unique
+  return @($unique | Sort-Object Created -Descending | Select-Object -First $script:MaxScriptEntries)
+}
+
+function Format-Flags {
+  param([string[]]$Flags)
+  if (-not $Flags -or $Flags.Count -eq 0) { return 'None' }
+  return ($Flags | Sort-Object -Unique) -join ', '
+}
+
+function Build-CandidateSummaries {
+  param(
+    [System.Collections.IEnumerable]$Candidates,
+    [string]$Prefix
+  )
+  $index = 1
+  $lines = New-Object 'System.Collections.Generic.List[string]'
+  foreach ($candidate in $Candidates) {
+    $candidate | Add-Member -NotePropertyName Id -NotePropertyValue ("{0}{1}" -f $Prefix, $index) -Force
+    $flags = Format-Flags -Flags $candidate.Flags
+    switch ($candidate.Type) {
+      'Task' {
+        $lines.Add(("{0}) Task {1} (RunAs={2}, Flags={3})" -f $candidate.Id, $candidate.FullName, $candidate.RunAsUser, $flags)) | Out-Null
+        $lines.Add(("    Action: {0}" -f $candidate.CommandLine)) | Out-Null
+        if ($candidate.TriggerSummary) { $lines.Add(("    Triggers: {0}" -f $candidate.TriggerSummary)) | Out-Null }
+        if ($candidate.RegistrationDate) { $lines.Add(("    Registered: {0:o}" -f $candidate.RegistrationDate)) | Out-Null }
+      }
+      'Process' {
+        $start = if ($candidate.StartTime) { $candidate.StartTime.ToString('o') } else { 'Unknown' }
+        $lines.Add(("{0}) Proc {1} (PID={2}, Signer={3}, Flags={4})" -f $candidate.Id, $candidate.Name, $candidate.ProcessId, $candidate.Signature, $flags)) | Out-Null
+        $lines.Add(("    Path: {0}" -f $candidate.Path)) | Out-Null
+        if ($candidate.CommandLine) { $lines.Add(("    Cmd: {0}" -f $candidate.CommandLine)) | Out-Null }
+        $lines.Add(("    Started: {0}" -f $start)) | Out-Null
+        if ($candidate.Listening.Count -gt 0) { $lines.Add(("    Listening: {0}" -f ($candidate.Listening -join '; '))) | Out-Null }
+        if ($candidate.Connections.Count -gt 0) { $lines.Add(("    Connections: {0}" -f ($candidate.Connections -join '; '))) | Out-Null }
+      }
+      'Script' {
+        $lines.Add(("{0}) Script {1} (Flags={2}, Created={3:o})" -f $candidate.Id, $candidate.Path, $flags, $candidate.Created)) | Out-Null
+        if ($candidate.Head) { $lines.Add("    Head: " + ($candidate.Head.Replace([Environment]::NewLine, ' '))) | Out-Null }
+        if ($candidate.Tail) { $lines.Add("    Tail: " + ($candidate.Tail.Replace([Environment]::NewLine, ' '))) | Out-Null }
+      }
+    }
+    $index++
+  }
+  return $lines -join [Environment]::NewLine
+}
+
+function Build-AiRequest {
+  param(
+    [System.Collections.IEnumerable]$Tasks,
+    [System.Collections.IEnumerable]$Processes,
+    [System.Collections.IEnumerable]$Scripts
+  )
+  $taskSummary = if ($Tasks -and $Tasks.Count -gt 0) { Build-CandidateSummaries -Candidates $Tasks -Prefix 'T' } else { 'None.' }
+  $processSummary = if ($Processes -and $Processes.Count -gt 0) { Build-CandidateSummaries -Candidates $Processes -Prefix 'P' } else { 'None.' }
+  $scriptSummary = if ($Scripts -and $Scripts.Count -gt 0) { Build-CandidateSummaries -Candidates $Scripts -Prefix 'S' } else { 'None.' }
+
+  $systemPrompt = @"
+You are a Windows malware hunter.
+You will receive a small set of scheduled tasks, running processes, and script files collected from a single host. These were pre-filtered to focus on user/profile locations, ProgramData/AppData/Public, inetpub, downloads/temp, or newly created folders.
+
+Your job:
+
+Identify items that are clearly malicious or unwanted persistence/tools and safe to delete in a CyberPatriot setting.
+
+Be conservative—if unsure, mark it for human review rather than deletion.
+
+Prioritize patterns like: interpreter launchers (powershell/wscript/cscript/cmd/mshta/python), encoded PowerShell, reverse/bind-shell behavior (-e, -enc, hidden windows, unusual listeners), droppers/stubs that only spawn shells, typical credential-theft terms (mimikatz/NTDS), unsigned binaries/scripts living in the locations above, and scheduled tasks with SYSTEM/highest privileges.
+
+Ignore normal system binaries in Windows\System32 that are properly Microsoft-signed unless used as a launcher as described.
+
+Return a short, human-readable list of what you think should be deleted and why, plus a separate short list of items that need manual review. Keep it minimal and actionable.
+"@
+
+  $userPrompt = @"
+Each item includes an ID (T#, P#, S#). Please reference these IDs when recommending deletions or reviews.
+
+SCHEDULED TASKS:
+$taskSummary
+
+PROCESSES:
+$processSummary
+
+SCRIPTS:
+$scriptSummary
+"@
+
+  $body = @{
+    model       = $script:AiModel
+    temperature = 0
+    max_tokens  = 1500
+    messages    = @(
+      @{ role = 'system'; content = $systemPrompt },
+      @{ role = 'user'; content = $userPrompt }
+    )
+  }
+
+  return $body | ConvertTo-Json -Depth 6
+}
+
+function Invoke-MalwareClassification {
+  param(
+    [System.Collections.IEnumerable]$Tasks,
+    [System.Collections.IEnumerable]$Processes,
+    [System.Collections.IEnumerable]$Scripts
+  )
+  if ((-not $Tasks -or $Tasks.Count -eq 0) -and (-not $Processes -or $Processes.Count -eq 0) -and (-not $Scripts -or $Scripts.Count -eq 0)) {
+    return ''
+  }
+
+  $apiKey = Get-OpenRouterApiKey
+  if (-not $apiKey) {
+    throw 'OpenRouter API key is missing; set the environment variable before running this module.'
+  }
+
+  $bodyJson = Build-AiRequest -Tasks $Tasks -Processes $Processes -Scripts $Scripts
+  $headers = @{ 'Authorization' = "Bearer $apiKey"; 'Content-Type' = 'application/json' }
+
+  try {
+    $response = Invoke-RestMethod -Uri $script:ApiUrl -Method Post -Headers $headers -Body $bodyJson -ErrorAction Stop
+  } catch {
+    throw ("OpenRouter API call failed: {0}" -f $_.Exception.Message)
+  }
+
+  $content = $response.choices[0].message.content
+  if (-not $content) {
+    throw 'OpenRouter returned an empty response.'
+  }
+  return $content.Trim()
+}
+
+function Parse-AiRecommendations {
+  param(
+    [string]$ResponseText,
+    [System.Collections.IEnumerable]$Candidates
+  )
+  $recommendations = @{}
+  foreach ($candidate in $Candidates) {
+    if (-not $candidate.Id) { continue }
+    $recommendations[$candidate.Id] = [pscustomobject]@{ Recommendation = 'None'; Reason = '' }
+  }
+  if (-not $ResponseText) { return $recommendations }
+
+  $lines = $ResponseText -split "`n"
+  foreach ($line in $lines) {
+    $trimmed = $line.Trim()
+    if (-not $trimmed) { continue }
+    foreach ($candidate in $Candidates) {
+      if (-not $candidate.Id) { continue }
+      if ($trimmed -notmatch [regex]::Escape($candidate.Id)) { continue }
+      $entry = $recommendations[$candidate.Id]
+      $lower = $trimmed.ToLowerInvariant()
+      $isDelete = ($lower -match 'delete|remove|quarantine|kill|terminate') -and ($lower -notmatch 'do not delete|keep')
+      $isReview = ($lower -match 'review|investigate|check|manual')
+      if ($isDelete) {
+        $entry.Recommendation = 'Delete'
+        $entry.Reason = $trimmed
+      } elseif ($entry.Recommendation -ne 'Delete') {
+        if ($isReview -or $entry.Recommendation -eq 'None') {
+          $entry.Recommendation = 'Review'
+          $entry.Reason = $trimmed
+        }
+      }
+    }
+  }
+
+  return $recommendations
+}
+
+function Get-AccessibilityStatus {
+  $results = New-Object 'System.Collections.Generic.List[object]'
+  foreach ($binary in $script:AccessibilityBinaries) {
+    $path = $null
+    try {
+      $path = Join-Path $env:windir (Join-Path 'System32' $binary)
+    } catch {
+      $path = ''
+    }
+    $issues = New-Object 'System.Collections.Generic.List[string]'
+    $signature = 'Missing'
+    if ($path -and (Test-Path -LiteralPath $path)) {
+      $signature = Get-SignatureStatus -Path $path
+      if ($signature -ne 'Microsoft') {
+        $issues.Add("SignatureStatus=$signature") | Out-Null
+      }
+    } else {
+      $issues.Add('FileMissing') | Out-Null
+    }
+    $results.Add([pscustomobject]@{
+      Name      = $binary
+      Path      = $path
+      Signature = $signature
+      Issues    = $issues.ToArray()
+    }) | Out-Null
+  }
+  return $results
+}
+
+function Invoke-QuarantineFile {
+  param([string]$Path)
+  if (-not $Path) { return $null }
+  if (-not (Test-Path -LiteralPath $Path)) { return $null }
+  try {
+    $directory = Split-Path -Path $Path -Parent
+    $name = Split-Path -Path $Path -Leaf
+    $candidateName = "$name.quarantined"
+    $counter = 1
+    $target = Join-Path $directory $candidateName
+    while (Test-Path -LiteralPath $target) {
+      $candidateName = "$name.quarantined$counter"
+      $target = Join-Path $directory $candidateName
+      $counter++
+    }
+    Rename-Item -LiteralPath $Path -NewName $candidateName -ErrorAction Stop
+    return $target
+  } catch {
+    Write-Warn ("Failed to quarantine {0}: {1}" -f $Path, $_.Exception.Message)
+    return $null
+  }
+}
+
+function Remove-TaskCandidate {
+  param($Candidate)
+  try {
+    Unregister-ScheduledTask -TaskName $Candidate.Name -TaskPath $Candidate.TaskPath -Confirm:$false -ErrorAction Stop
+    Write-Info ("Removed scheduled task {0}" -f $Candidate.FullName)
+  } catch {
+    Write-Warn ("Failed to remove task {0}: {1}" -f $Candidate.FullName, $_.Exception.Message)
+  }
+  if ($Candidate.ActionPath -and (Test-IsSuspiciousPath -Path $Candidate.ActionPath) -and (Test-Path -LiteralPath $Candidate.ActionPath)) {
+    $quarantine = Invoke-QuarantineFile -Path $Candidate.ActionPath
+    if ($quarantine) {
+      Write-Info ("Quarantined task payload {0}" -f $quarantine)
+    }
+  }
+}
+
+function Remove-ProcessCandidate {
+  param($Candidate)
+  if ($Candidate.ProcessId) {
+    try {
+      Stop-Process -Id $Candidate.ProcessId -Force -ErrorAction Stop
+      Write-Info ("Terminated process {0} (PID {1})" -f $Candidate.Name, $Candidate.ProcessId)
+    } catch {
+      Write-Warn ("Failed to terminate PID {0}: {1}" -f $Candidate.ProcessId, $_.Exception.Message)
+    }
+  }
+  if ($Candidate.Path -and (Test-IsSuspiciousPath -Path $Candidate.Path) -and (Test-Path -LiteralPath $Candidate.Path)) {
+    $quarantine = Invoke-QuarantineFile -Path $Candidate.Path
+    if ($quarantine) {
+      Write-Info ("Quarantined process binary {0}" -f $quarantine)
+    }
+  }
+}
+
+function Remove-ScriptCandidate {
+  param($Candidate)
+  if (-not $Candidate.Path) { return }
+  if (-not (Test-Path -LiteralPath $Candidate.Path)) { return }
+  $quarantine = Invoke-QuarantineFile -Path $Candidate.Path
+  if ($quarantine) {
+    Write-Info ("Quarantined script {0}" -f $quarantine)
+  }
+}
+
+function Restore-AccessibilityBinary {
+  param($Status)
+  if (-not $Status.Path) { return $false }
+  $sfcPath = Join-Path $env:windir 'System32\sfc.exe'
+  if (-not (Test-Path -LiteralPath $sfcPath)) {
+    Write-Warn 'sfc.exe not found; cannot attempt restoration.'
+    return $false
+  }
+  try {
+    Write-Info ("Attempting SFC restore for {0}" -f $Status.Path)
+    $process = Start-Process -FilePath $sfcPath -ArgumentList ("/scanfile=\"{0}\"" -f $Status.Path) -Wait -PassThru -WindowStyle Hidden -ErrorAction Stop
+    if ($process.ExitCode -eq 0) {
+      Write-Info ("SFC completed for {0}" -f $Status.Path)
+      return $true
+    }
+    Write-Warn ("SFC exited with code {0} for {1}" -f $process.ExitCode, $Status.Path)
+  } catch {
+    Write-Warn ("Failed to run SFC for {0}: {1}" -f $Status.Path, $_.Exception.Message)
+  }
+  return $false
+}
+
+function Invoke-MalwareAssessment {
+  param([switch]$Remove)
+
+  $tasks = Get-TaskCandidates
+  $processes = Get-ProcessCandidates
+  $scripts = Get-ScriptCandidates
+
+  if (($tasks.Count + $processes.Count + $scripts.Count) -eq 0) {
+    return [pscustomobject]@{
+      Tasks           = @()
+      Processes       = @()
+      Scripts         = @()
+      Accessibility   = Get-AccessibilityStatus
+      AiResponse      = ''
+      Recommendations = @{}
+      Removed         = @()
+    }
+  }
+
+  Write-Info ("Collected {0} suspicious tasks, {1} processes, {2} scripts" -f $tasks.Count, $processes.Count, $scripts.Count)
+
+  $aiResponse = ''
+  try {
+    Write-Info 'Submitting snapshot to OpenRouter for triage'
+    $aiResponse = Invoke-MalwareClassification -Tasks $tasks -Processes $processes -Scripts $scripts
+  } catch {
+    Write-Warn ("AI classification failed: {0}" -f $_.Exception.Message)
+  }
+
+  $allCandidates = @($tasks + $processes + $scripts)
+  $recommendations = if ($aiResponse) { Parse-AiRecommendations -ResponseText $aiResponse -Candidates $allCandidates } else { @{} }
+
+  $removed = New-Object 'System.Collections.Generic.List[string]'
+  if ($Remove -and $recommendations.Count -gt 0) {
+    $deleteCandidates = @()
+    foreach ($candidate in $allCandidates) {
+      if (-not $candidate.Id) { continue }
+      if ($recommendations.ContainsKey($candidate.Id) -and $recommendations[$candidate.Id].Recommendation -eq 'Delete') {
+        $deleteCandidates += $candidate
+      }
+    }
+
+    if ($deleteCandidates.Count -gt 0) {
+      Write-Host ''
+      Write-Host 'AI suggested deleting the following items:'
+      foreach ($candidate in $deleteCandidates) {
+        $reason = $recommendations[$candidate.Id].Reason
+        Write-Host ("  - {0} ({1})" -f $candidate.Id, $reason)
+      }
+      $response = Read-Host 'Proceed? (A=all, M=manual, N=skip) [A]'
+      if ([string]::IsNullOrWhiteSpace($response)) { $response = 'A' }
+      $response = $response.Trim().Substring(0,1).ToUpperInvariant()
+      if ($response -eq 'A') {
+        foreach ($candidate in $deleteCandidates) {
+          switch ($candidate.Type) {
+            'Task' { Remove-TaskCandidate -Candidate $candidate }
+            'Process' { Remove-ProcessCandidate -Candidate $candidate }
+            'Script' { Remove-ScriptCandidate -Candidate $candidate }
+          }
+          $removed.Add($candidate.Id) | Out-Null
+        }
+      } elseif ($response -eq 'M') {
+        foreach ($candidate in $deleteCandidates) {
+          $reason = $recommendations[$candidate.Id].Reason
+          $choice = Read-Host ("Remove {0}? (Reason: {1}) [Y/N]" -f $candidate.Id, $reason)
+          if ([string]::IsNullOrWhiteSpace($choice)) { $choice = 'Y' }
+          if ($choice.Trim().StartsWith('Y', [System.StringComparison]::OrdinalIgnoreCase)) {
+            switch ($candidate.Type) {
+              'Task' { Remove-TaskCandidate -Candidate $candidate }
+              'Process' { Remove-ProcessCandidate -Candidate $candidate }
+              'Script' { Remove-ScriptCandidate -Candidate $candidate }
+            }
+            $removed.Add($candidate.Id) | Out-Null
+          }
+        }
+      } else {
+        Write-Info 'Skipping removal per operator request.'
+      }
+    } else {
+      Write-Info 'AI did not recommend any deletions.'
+    }
+  }
+
+  $accessibility = Get-AccessibilityStatus
+  if ($Remove) {
+    foreach ($status in $accessibility) {
+      if ($status.Issues.Count -eq 0) { continue }
+      $choice = Read-Host ("Restore {0}? (issues: {1}) [Y/N]" -f $status.Path, ($status.Issues -join ', '))
+      if ([string]::IsNullOrWhiteSpace($choice)) { $choice = 'Y' }
+      if ($choice.Trim().StartsWith('Y', [System.StringComparison]::OrdinalIgnoreCase)) {
+        Restore-AccessibilityBinary -Status $status | Out-Null
+      }
+    }
+  }
+
+  return [pscustomobject]@{
+    Tasks           = @($tasks)
+    Processes       = @($processes)
+    Scripts         = @($scripts)
+    Accessibility   = @($accessibility)
+    AiResponse      = $aiResponse
+    Recommendations = $recommendations
+    Removed         = @($removed)
+  }
+}
+
+function Summarize-Recommendations {
+  param($Result)
+  if (-not $Result -or $Result.Recommendations.Count -eq 0) { return 'No AI guidance available.' }
+  $delete = 0
+  $review = 0
+  foreach ($entry in $Result.Recommendations.GetEnumerator()) {
+    switch ($entry.Value.Recommendation) {
+      'Delete' { $delete++ }
+      'Review' { $review++ }
+    }
+  }
+  return ("AI flagged {0} deletion(s) and {1} review(s)." -f $delete, $review)
+}
+
+function Summarize-Accessibility {
+  param($Statuses)
+  if (-not $Statuses -or $Statuses.Count -eq 0) { return 'Sticky keys binaries not evaluated.' }
+  $issues = $Statuses | Where-Object { $_.Issues.Count -gt 0 }
+  if (-not $issues -or $issues.Count -eq 0) { return 'Sticky keys binaries verified as Microsoft-signed.' }
+  $labels = $issues | ForEach-Object { "{0} ({1})" -f $_.Name, ($_.Issues -join ', ') }
+  return ('Sticky keys anomalies: ' + ($labels -join '; '))
+}
+
+function Test-Ready {
+  param($Context)
+  if (-not (Get-OpenRouterApiKey)) {
+    Write-Warn "OpenRouter API key is missing (set `$env:$($script:ApiKeyEnvVar))."
+    return $false
+  }
+  return $true
+}
+
+function Invoke-Verify {
+  param($Context)
+  try {
+    $result = Invoke-MalwareAssessment
+  } catch {
+    Write-Err ("MalwarePersistence verification failed: {0}" -f $_.Exception.Message)
+    return (New-ModuleResult -Name $script:ModuleName -Status 'Failed' -Message ('Verification error: ' + $_.Exception.Message))
+  }
+
+  $summary = Summarize-Recommendations -Result $result
+  $accessSummary = Summarize-Accessibility -Statuses $result.Accessibility
+  $message = "$summary $accessSummary".Trim()
+  if (-not $message) { $message = 'Malware persistence scan completed.' }
+
+  return (New-ModuleResult -Name $script:ModuleName -Status 'Succeeded' -Message $message)
+}
+
+function Invoke-Apply {
+  param($Context)
+  try {
+    $result = Invoke-MalwareAssessment -Remove
+  } catch {
+    Write-Err ("MalwarePersistence apply failed: {0}" -f $_.Exception.Message)
+    return (New-ModuleResult -Name $script:ModuleName -Status 'Failed' -Message ('Apply error: ' + $_.Exception.Message))
+  }
+
+  $summary = Summarize-Recommendations -Result $result
+  $removedText = if ($result.Removed.Count -gt 0) { "Removed {0} item(s)." -f $result.Removed.Count } else { 'No items removed.' }
+  $accessSummary = Summarize-Accessibility -Statuses $result.Accessibility
+  $message = "$summary $removedText $accessSummary".Trim()
+  if (-not $message) { $message = 'Malware persistence remediation completed.' }
+
+  return (New-ModuleResult -Name $script:ModuleName -Status 'Succeeded' -Message $message)
+}
 
 Export-ModuleMember -Function Test-Ready,Invoke-Verify,Invoke-Apply


### PR DESCRIPTION
## Summary
- add full malware persistence scanning module that inventories suspicious tasks, processes, and scripts
- integrate OpenRouter triage workflow using CyberPatriot-focused prompt with ID-tagged items for deletion/review guidance
- provide operator removal flow with quarantine helpers and sticky keys integrity check plus optional SFC restoration

## Testing
- Not run (PowerShell is not available in the container)


------
https://chatgpt.com/codex/tasks/task_e_6901140bac7c833380d424e9905d34b9