### PR TITLE
Fix firewall import and policy copy arguments

### DIFF
--- a/modules/02_LocalAccountPolicy/LocalAccountPolicy.psm1
+++ b/modules/02_LocalAccountPolicy/LocalAccountPolicy.psm1
@@ -40,8 +40,8 @@ function Invoke-CopyTree {
   $robo = Get-Command 'robocopy.exe' -ErrorAction SilentlyContinue
   if ($robo) {
     $args = @(
-      '"{0}"' -f $Source,
-      '"{0}"' -f $Destination,
+      $Source,
+      $Destination,
       '/E',
       '/R:1',
       '/W:1',

--- a/modules/05_Defensive/Defensive.psm1
+++ b/modules/05_Defensive/Defensive.psm1
@@ -44,7 +44,7 @@ function Invoke-ImportFirewallProfile {
   }
 
   Write-Info 'Importing firewall profile using netsh'
-  $args = @('advfirewall', 'import', "\"$($script:FirewallFile)\"")
+  $args = @('advfirewall', 'import', $script:FirewallFile)
   $proc = Start-Process -FilePath 'netsh.exe' -ArgumentList $args -Wait -PassThru -NoNewWindow
   if ($proc.ExitCode -ne 0) {
     throw ("netsh advfirewall import failed with exit code {0}" -f $proc.ExitCode)


### PR DESCRIPTION
## Summary
- fix netsh argument quoting to prevent PowerShell parse errors in the Defensive module
- remove unnecessary robocopy quoting so destination paths are passed correctly in the LocalAccountPolicy module

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_6901793992c483338347a55b821b5a2c