### PR TITLE
Fix module syntax issues and raise AI output limits

### DIFF
--- a/modules/09_ProhibitedFiles/ProhibitedFiles.psm1
+++ b/modules/09_ProhibitedFiles/ProhibitedFiles.psm1
@@ -344,7 +344,7 @@ You are reviewing potential prohibited files on a Windows host.
 README CONTENT:
 $ReadmeText
 
-PROHIBITED FILE CANDIDATES (first $($Summaries.Count) entries):
+PROHIBITED FILE CANDIDATES ($($Summaries.Count) entries):
 $inventoryBlock
 
 Return ONLY a JSON array of the exact file paths that must be removed.
@@ -353,7 +353,7 @@ Return ONLY a JSON array of the exact file paths that must be removed.
   $body = @{
     model       = 'openai/gpt-5'
     temperature = 0
-    max_tokens  = 2000
+    max_tokens  = 8000
     messages    = @(
       @{ role = 'system'; content = $systemPrompt },
       @{ role = 'user'; content = $userPrompt }

--- a/modules/11_MalwarePersistence/MalwarePersistence.psm1
+++ b/modules/11_MalwarePersistence/MalwarePersistence.psm1
@@ -664,7 +664,7 @@ function Restore-AccessibilityBinary {
   }
   try {
     Write-Info ("Attempting SFC restore for {0}" -f $Status.Path)
-    $process = Start-Process -FilePath $sfcPath -ArgumentList ("/scanfile=\"{0}\"" -f $Status.Path) -Wait -PassThru -WindowStyle Hidden -ErrorAction Stop
+    $process = Start-Process -FilePath $sfcPath -ArgumentList ('/scanfile=""{0}""' -f $Status.Path) -Wait -PassThru -WindowStyle Hidden -ErrorAction Stop
     if ($process.ExitCode -eq 0) {
       Write-Info ("SFC completed for {0}" -f $Status.Path)
       return $true

--- a/modules/12_UncategorizedOS/UncategorizedOS.psm1
+++ b/modules/12_UncategorizedOS/UncategorizedOS.psm1
@@ -15,14 +15,16 @@ $script:MaxReadmeCharacters     = 6000
 $script:MaxShareEntries         = 50
 $script:DefaultShareNames       = [System.Collections.Generic.HashSet[string]]::new([System.StringComparer]::OrdinalIgnoreCase)
 $script:LastRemovedShares       = @()
-$script:WriteRightsMask         = [System.Security.AccessControl.FileSystemRights]::FullControl -bor \
-  [System.Security.AccessControl.FileSystemRights]::Modify -bor \
-  [System.Security.AccessControl.FileSystemRights]::Write -bor \
-  [System.Security.AccessControl.FileSystemRights]::WriteData -bor \
-  [System.Security.AccessControl.FileSystemRights]::CreateFiles -bor \
-  [System.Security.AccessControl.FileSystemRights]::CreateDirectories -bor \
-  [System.Security.AccessControl.FileSystemRights]::AppendData -bor \
-  [System.Security.AccessControl.FileSystemRights]::ChangePermissions
+$script:WriteRightsMask         = (
+  [System.Security.AccessControl.FileSystemRights]::FullControl
+  -bor [System.Security.AccessControl.FileSystemRights]::Modify
+  -bor [System.Security.AccessControl.FileSystemRights]::Write
+  -bor [System.Security.AccessControl.FileSystemRights]::WriteData
+  -bor [System.Security.AccessControl.FileSystemRights]::CreateFiles
+  -bor [System.Security.AccessControl.FileSystemRights]::CreateDirectories
+  -bor [System.Security.AccessControl.FileSystemRights]::AppendData
+  -bor [System.Security.AccessControl.FileSystemRights]::ChangePermissions
+)
 
 foreach ($name in @('ADMIN$','IPC$','C$','D$','E$','F$','G$','H$','PRINT$','FAX$','SYSVOL','NETLOGON')) {
   [void]$script:DefaultShareNames.Add($name)

--- a/modules/14_Forensics/ForensicsQuestions.psm1
+++ b/modules/14_Forensics/ForensicsQuestions.psm1
@@ -526,11 +526,11 @@ function Execute-RequestedCommands {
   $count = 0
   foreach ($req in $Requests) {
     if ($count -ge $script:MaxCommandRequests) {
-      $results.Add([pscustomobject]@{ Command=$req; Allowed=$false; Success=$false; Output=''; Error='Request limit exceeded.' }) | Out-Null
+      [void]$results.Add([pscustomobject]@{ Command=$req; Allowed=$false; Success=$false; Output=''; Error='Request limit exceeded.' })
       continue
     }
     $count++
-    $results.Add(Invoke-AllowedCommand -Command $req) | Out-Null
+    [void]$results.Add(Invoke-AllowedCommand -Command $req)
   }
 
   return @($results)


### PR DESCRIPTION
## Summary
- fix syntax errors in the Forensics, Uncategorized OS, and Malware Persistence modules
- increase OpenRouter max token limits for prohibited file and unwanted software classification
- stop truncating the unwanted software inventory before sending it to the classifier

## Testing
- pwsh -NoLogo -NoProfile -Command "Import-Module 'modules/14_Forensics/ForensicsQuestions.psm1'" *(fails: PowerShell is not installed in the container)*

------
https://chatgpt.com/codex/tasks/task_e_6901892f53bc8333b994a31bb6e2effe