### PR TITLE
Fix user hardening warning string syntax

### DIFF
--- a/modules/01_UserAuditing/UserAuditing.psm1
+++ b/modules/01_UserAuditing/UserAuditing.psm1
@@ -180,7 +180,7 @@ function Invoke-Apply {
       [void](Set-LocalUserCanChangePassword -Name $u -CanChange:$true)
       Write-Ok "Hardened user $u"
     } catch {
-      Write-Warn "Failed to harden $u: $($_.Exception.Message)"
+      Write-Warn "Failed to harden ${u}: $($_.Exception.Message)"
     }
   }
 


### PR DESCRIPTION
## Summary
- escape the username interpolation in the UserAuditing warning message so PowerShell parses the string correctly

## Testing
- Not run (pwsh unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_69026074f4cc83339542b89c31e8e217