### PR TITLE
Improve malware persistence path handling

### DIFF
--- a/modules/11_MalwarePersistence/MalwarePersistence.psm1
+++ b/modules/11_MalwarePersistence/MalwarePersistence.psm1
@@ -40,8 +40,9 @@ function Get-OpenRouterApiKey {
 function Normalize-Path {
   param([string]$Path)
   if ([string]::IsNullOrWhiteSpace($Path)) { return '' }
-  $normalized = $Path -replace '[\\/]+', '\\'
-  $normalized = $normalized.Trim()
+  $normalized = $Path.Trim()
+  $normalized = $normalized.Trim(@([char]34, [char]39))
+  $normalized = $normalized -replace '[\\/]+', '\\'
   return $normalized
 }
 
@@ -63,9 +64,13 @@ function Test-IsRecentDirectory {
   param([string]$Path)
   if (-not $Path) { return $false }
   try {
-    $directory = Split-Path -Path $Path -Parent
+    $normalized = Normalize-Path -Path $Path
+    if (-not $normalized) { return $false }
+    $expanded = [Environment]::ExpandEnvironmentVariables($normalized)
+    if ([string]::IsNullOrWhiteSpace($expanded)) { return $false }
+    $directory = Split-Path -LiteralPath $expanded -Parent -ErrorAction Stop
     if (-not $directory) { return $false }
-    if (-not (Test-Path -LiteralPath $directory)) { return $false }
+    if (-not (Test-Path -LiteralPath $directory -ErrorAction Stop)) { return $false }
     $dirInfo = Get-Item -LiteralPath $directory -ErrorAction Stop
     $age = (Get-Date) - $dirInfo.CreationTime
     return ($age.TotalDays -le $script:RecentDaysThreshold)


### PR DESCRIPTION
## Summary
- strip wrapping quotes while normalizing file paths in the malware persistence module
- expand environment variables before checking directory metadata to avoid illegal path errors
- harden recent-directory checks with terminating Test-Path lookups for reliable error handling

## Testing
- not run (Windows-specific module)

------
https://chatgpt.com/codex/tasks/task_e_6902610f8350833390e385ad4b6fe941