### PR TITLE
Fix WriteRightsMask expression in UncategorizedOS module

### DIFF
--- a/modules/12_UncategorizedOS/UncategorizedOS.psm1
+++ b/modules/12_UncategorizedOS/UncategorizedOS.psm1
@@ -15,16 +15,14 @@ $script:MaxReadmeCharacters     = 6000
 $script:MaxShareEntries         = 50
 $script:DefaultShareNames       = [System.Collections.Generic.HashSet[string]]::new([System.StringComparer]::OrdinalIgnoreCase)
 $script:LastRemovedShares       = @()
-$script:WriteRightsMask         = (
-  [System.Security.AccessControl.FileSystemRights]::FullControl
-  -bor [System.Security.AccessControl.FileSystemRights]::Modify
-  -bor [System.Security.AccessControl.FileSystemRights]::Write
-  -bor [System.Security.AccessControl.FileSystemRights]::WriteData
-  -bor [System.Security.AccessControl.FileSystemRights]::CreateFiles
-  -bor [System.Security.AccessControl.FileSystemRights]::CreateDirectories
-  -bor [System.Security.AccessControl.FileSystemRights]::AppendData
+$script:WriteRightsMask         = [System.Security.AccessControl.FileSystemRights]::FullControl `
+  -bor [System.Security.AccessControl.FileSystemRights]::Modify `
+  -bor [System.Security.AccessControl.FileSystemRights]::Write `
+  -bor [System.Security.AccessControl.FileSystemRights]::WriteData `
+  -bor [System.Security.AccessControl.FileSystemRights]::CreateFiles `
+  -bor [System.Security.AccessControl.FileSystemRights]::CreateDirectories `
+  -bor [System.Security.AccessControl.FileSystemRights]::AppendData `
   -bor [System.Security.AccessControl.FileSystemRights]::ChangePermissions
-)
 
 foreach ($name in @('ADMIN$','IPC$','C$','D$','E$','F$','G$','H$','PRINT$','FAX$','SYSVOL','NETLOGON')) {
   [void]$script:DefaultShareNames.Add($name)


### PR DESCRIPTION
## Summary
- rewrite the WriteRightsMask initialization to use explicit line continuations so PowerShell parses the bitmask correctly

## Testing
- not run (PowerShell runtime not available in container)


------
https://chatgpt.com/codex/tasks/task_e_6902612044848333b7c4d7ca574f7760