### PR TITLE
Fix Forensics command execution syntax

### DIFF
--- a/modules/14_Forensics/ForensicsQuestions.psm1
+++ b/modules/14_Forensics/ForensicsQuestions.psm1
@@ -530,7 +530,7 @@ function Execute-RequestedCommands {
       continue
     }
     $count++
-    [void]$results.Add(Invoke-AllowedCommand -Command $req)
+    [void]$results.Add((Invoke-AllowedCommand -Command $req))
   }
 
   return @($results)


### PR DESCRIPTION
## Summary
- wrap Invoke-AllowedCommand call in parentheses when adding to results list to satisfy PowerShell syntax

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_69026178fc608333a5af26bbf736fb5b