### PR TITLE
Increase token budget for ForensicsQuestions

### DIFF
--- a/modules/14_Forensics/ForensicsQuestions.psm1
+++ b/modules/14_Forensics/ForensicsQuestions.psm1
@@ -11,6 +11,17 @@ $script:ModuleName            = 'ForensicsQuestions'
 $script:ApiUrl                = 'https://openrouter.ai/api/v1/chat/completions'
 $script:ApiKeyEnvVar          = 'OPENROUTER_API_KEY'
 $script:OpenRouterModel       = if ($env:OPENROUTER_MODEL) { $env:OPENROUTER_MODEL } else { 'openai/gpt-5' }
+$script:OpenRouterMaxTokens   = {
+  $default = 4000
+  if (-not $env:OPENROUTER_MAX_TOKENS) { return $default }
+
+  $parsed = 0
+  if ([int]::TryParse($env:OPENROUTER_MAX_TOKENS, [ref]$parsed)) {
+    if ($parsed -gt 0) { return $parsed }
+  }
+
+  return $default
+}.Invoke()
 $script:QuestionPattern       = 'Forensics Question *.txt'
 $script:PlaceholderPattern    = '^(ANSWER:\s*)(<Type Answer Here>)(\s*)$'
 $script:PlaceholderRegex      = New-Object System.Text.RegularExpressions.Regex($script:PlaceholderPattern, [System.Text.RegularExpressions.RegexOptions]::Multiline)
@@ -150,7 +161,7 @@ function Build-InitialUserPrompt {
 function Invoke-ChatCompletion {
   param(
     [object[]]$Messages,
-    [int]$MaxTokens = 600
+    [int]$MaxTokens = $script:OpenRouterMaxTokens
   )
 
   $apiKey = Get-OpenRouterApiKey


### PR DESCRIPTION
## Summary
- raise the default token budget used for OpenRouter chat completions in the forensics module
- allow overriding the token limit via the OPENROUTER_MAX_TOKENS environment variable

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_6902643ab4bc8333a64efe2e212a2b80