### PR TITLE
Increase ServiceHardening AI token budget

### DIFF
--- a/modules/06_ServiceAuditing/ServiceAuditing.psm1
+++ b/modules/06_ServiceAuditing/ServiceAuditing.psm1
@@ -11,6 +11,7 @@ if (-not (Get-Command New-ModuleResult -EA SilentlyContinue)) {
 $script:ServicePlanModel        = if ($env:OPENROUTER_MODEL) { $env:OPENROUTER_MODEL } else { 'openai/gpt-5' }
 $script:ServicePlanMaxServices  = 200
 $script:ServicePlanEndpoint     = 'https://openrouter.ai/api/v1/chat/completions'
+$script:ServicePlanMaxTokens    = 6000
 
 function ConvertTo-PlainText {
   param([string]$Html)
@@ -72,7 +73,7 @@ Only output valid JSON for the directive object.
     model       = $script:ServicePlanModel
     temperature = 0
     top_p       = 1
-    max_tokens  = 2000
+    max_tokens  = $script:ServicePlanMaxTokens
     messages    = @(
       @{ role = 'system'; content = $systemPrompt },
       @{ role = 'user'; content = $userPrompt }


### PR DESCRIPTION
## Summary
- add a configurable max token value for the ServiceHardening AI request
- raise the completion token limit to 6000 to prevent responses from being cut off

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_6902658b8db88333b65c1968f9f2a746