### PR TITLE
Remove AllowTSConnections registry setting from UncategorizedOS

### DIFF
--- a/modules/12_UncategorizedOS/UncategorizedOS.psm1
+++ b/modules/12_UncategorizedOS/UncategorizedOS.psm1
@@ -92,7 +92,6 @@ function Disable-RemoteDesktopFeatures {
   $changed = (Ensure-RegistryValue -Path 'HKLM:\System\CurrentControlSet\Control\Terminal Server' -Name 'fDenyTSConnections' -Type 'DWord' -Value 1) -or $changed
   $changed = (Ensure-RegistryValue -Path 'HKLM:\SYSTEM\CurrentControlSet\Control\Remote Assistance' -Name 'fAllowToGetHelp' -Type 'DWord' -Value 0) -or $changed
   $changed = (Ensure-RegistryValue -Path 'HKLM:\SYSTEM\CurrentControlSet\Control\Remote Assistance' -Name 'fAllowFullControl' -Type 'DWord' -Value 0) -or $changed
-  $changed = (Ensure-RegistryValue -Path 'HKLM:\System\CurrentControlSet\Control\Terminal Server' -Name 'AllowTSConnections' -Type 'DWord' -Value 0) -or $changed
   return $changed
 }
 


### PR DESCRIPTION
## Summary
- remove the AllowTSConnections registry value configuration from the UncategorizedOS module to match the working script and avoid runtime errors

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_690265fdd67c833382f0823139653939