### PR TITLE
Fix MalwarePersistence candidate counting and extend AI token budget

### DIFF
--- a/modules/11_MalwarePersistence/MalwarePersistence.psm1
+++ b/modules/11_MalwarePersistence/MalwarePersistence.psm1
@@ -484,7 +484,7 @@ $scriptSummary
   $body = @{
     model       = $script:AiModel
     temperature = 0
-    max_tokens  = 1500
+    max_tokens  = 5000
     messages    = @(
       @{ role = 'system'; content = $systemPrompt },
       @{ role = 'user'; content = $userPrompt }
@@ -684,16 +684,16 @@ function Restore-AccessibilityBinary {
 function Invoke-MalwareAssessment {
   param([switch]$Remove)
 
-  $tasks = Get-TaskCandidates
-  $processes = Get-ProcessCandidates
-  $scripts = Get-ScriptCandidates
+  $tasks = @(Get-TaskCandidates)
+  $processes = @(Get-ProcessCandidates)
+  $scripts = @(Get-ScriptCandidates)
 
   if (($tasks.Count + $processes.Count + $scripts.Count) -eq 0) {
     return [pscustomobject]@{
       Tasks           = @()
       Processes       = @()
       Scripts         = @()
-      Accessibility   = Get-AccessibilityStatus
+      Accessibility   = @(Get-AccessibilityStatus)
       AiResponse      = ''
       Recommendations = @{}
       Removed         = @()
@@ -764,7 +764,7 @@ function Invoke-MalwareAssessment {
     }
   }
 
-  $accessibility = Get-AccessibilityStatus
+  $accessibility = @(Get-AccessibilityStatus)
   if ($Remove) {
     foreach ($status in $accessibility) {
       if ($status.Issues.Count -eq 0) { continue }
@@ -777,13 +777,13 @@ function Invoke-MalwareAssessment {
   }
 
   return [pscustomobject]@{
-    Tasks           = @($tasks)
-    Processes       = @($processes)
-    Scripts         = @($scripts)
-    Accessibility   = @($accessibility)
+    Tasks           = $tasks
+    Processes       = $processes
+    Scripts         = $scripts
+    Accessibility   = $accessibility
     AiResponse      = $aiResponse
     Recommendations = $recommendations
-    Removed         = @($removed)
+    Removed         = $removed.ToArray()
   }
 }
 


### PR DESCRIPTION
## Summary
- coerce task, process, and script candidate results into arrays so `.Count` checks are reliable
- normalize returned accessibility/removal collections and raise the OpenRouter `max_tokens` budget to 5000 for longer triage output

## Testing
- not run (PowerShell module depends on Windows-specific tooling)


------
https://chatgpt.com/codex/tasks/task_e_690265c60c548333b5314de75d4bfe19