### PR TITLE
Fix max tokens handling in forensics module

### DIFF
--- a/modules/14_Forensics/ForensicsQuestions.psm1
+++ b/modules/14_Forensics/ForensicsQuestions.psm1
@@ -11,17 +11,7 @@ $script:ModuleName            = 'ForensicsQuestions'
 $script:ApiUrl                = 'https://openrouter.ai/api/v1/chat/completions'
 $script:ApiKeyEnvVar          = 'OPENROUTER_API_KEY'
 $script:OpenRouterModel       = if ($env:OPENROUTER_MODEL) { $env:OPENROUTER_MODEL } else { 'openai/gpt-5' }
-$script:OpenRouterMaxTokens   = {
-  $default = 4000
-  if (-not $env:OPENROUTER_MAX_TOKENS) { return $default }
-
-  $parsed = 0
-  if ([int]::TryParse($env:OPENROUTER_MAX_TOKENS, [ref]$parsed)) {
-    if ($parsed -gt 0) { return $parsed }
-  }
-
-  return $default
-}.Invoke()
+$script:OpenRouterMaxTokens   = 6000
 $script:QuestionPattern       = 'Forensics Question *.txt'
 $script:PlaceholderPattern    = '^(ANSWER:\s*)(<Type Answer Here>)(\s*)$'
 $script:PlaceholderRegex      = New-Object System.Text.RegularExpressions.Regex($script:PlaceholderPattern, [System.Text.RegularExpressions.RegexOptions]::Multiline)


### PR DESCRIPTION
## Summary
- set the ForensicsQuestions max token value to a static 6000 to match other modules
- remove the environment-driven logic that caused a non-integer value to reach the MaxTokens parameter

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_69026b3cbd748333a2c6386654b863da