### PR TITLE
Fix Forensics command handling

### DIFF
--- a/modules/14_Forensics/ForensicsQuestions.psm1
+++ b/modules/14_Forensics/ForensicsQuestions.psm1
@@ -264,7 +264,7 @@ function Limit-Output {
 function Split-CommandLine {
   param([string]$Command)
 
-  $parts = New-Object System.Collections.Generic.List[string]
+  $parts = New-Object 'System.Collections.Generic.List[string]'
   if ([string]::IsNullOrWhiteSpace($Command)) { return @() }
 
   $current = New-Object System.Text.StringBuilder
@@ -299,7 +299,7 @@ function Split-CommandLine {
   }
 
   if ($current.Length -gt 0) { $parts.Add($current.ToString()) | Out-Null }
-  return @($parts)
+  return $parts.ToArray()
 }
 
 function Read-FileSample {
@@ -521,7 +521,7 @@ function Invoke-AllowedCommand {
 function Execute-RequestedCommands {
   param([string[]]$Requests)
 
-  $results = New-Object System.Collections.Generic.List[object]
+  $results = New-Object 'System.Collections.Generic.List[object]'
   if (-not $Requests) { return @() }
 
   $count = 0
@@ -534,7 +534,7 @@ function Execute-RequestedCommands {
     [void]$results.Add((Invoke-AllowedCommand -Command $req))
   }
 
-  return @($results)
+  return $results.ToArray()
 }
 
 function Build-CommandResultsPrompt {


### PR DESCRIPTION
## Summary
- return PowerShell generic lists as arrays so downstream code receives the expected object[]
- ensure generic List creations use quoted type names to avoid type binding errors

## Testing
- Not run (pwsh is unavailable in the container environment)


------
https://chatgpt.com/codex/tasks/task_e_6902707966a88333832a0c577f1ed3f1