### PR TITLE
Fix strict mode handling in MalwarePersistence counts

### DIFF
--- a/modules/11_MalwarePersistence/MalwarePersistence.psm1
+++ b/modules/11_MalwarePersistence/MalwarePersistence.psm1
@@ -283,7 +283,7 @@ function Get-ProcessCandidates {
       $listening = $connections.Listening.ToArray()
       $established = $connections.Established.ToArray()
     }
-    $shouldKeep = $isSuspiciousPath -or $isInterpreter -or $isRecentDir -or ($flags.Count -gt 0) -or ($listening.Count -gt 0)
+    $shouldKeep = $isSuspiciousPath -or $isInterpreter -or $isRecentDir -or ($flags.Count -gt 0) -or (@($listening).Count -gt 0)
     if (-not $shouldKeep) { continue }
 
     $flagSet = New-Object 'System.Collections.Generic.List[string]'
@@ -291,7 +291,7 @@ function Get-ProcessCandidates {
     if ($isInterpreter) { $flagSet.Add('InterpreterProcess') | Out-Null }
     foreach ($flag in $flags) { if ($flag) { $flagSet.Add($flag) | Out-Null } }
     if ($isRecentDir) { $flagSet.Add('RecentFolder') | Out-Null }
-    if ($listening.Count -gt 0) { $flagSet.Add('ListeningPort') | Out-Null }
+    if (@($listening).Count -gt 0) { $flagSet.Add('ListeningPort') | Out-Null }
 
     $signatureStatus = Get-SignatureStatus -Path $path
 
@@ -400,8 +400,9 @@ function Get-ScriptCandidates {
 
 function Format-Flags {
   param([string[]]$Flags)
-  if (-not $Flags -or $Flags.Count -eq 0) { return 'None' }
-  return ($Flags | Sort-Object -Unique) -join ', '
+  $normalized = @($Flags)
+  if ($normalized.Count -eq 0) { return 'None' }
+  return ($normalized | Sort-Object -Unique) -join ', '
 }
 
 function Build-CandidateSummaries {
@@ -427,8 +428,8 @@ function Build-CandidateSummaries {
         $lines.Add(("    Path: {0}" -f $candidate.Path)) | Out-Null
         if ($candidate.CommandLine) { $lines.Add(("    Cmd: {0}" -f $candidate.CommandLine)) | Out-Null }
         $lines.Add(("    Started: {0}" -f $start)) | Out-Null
-        if ($candidate.Listening.Count -gt 0) { $lines.Add(("    Listening: {0}" -f ($candidate.Listening -join '; '))) | Out-Null }
-        if ($candidate.Connections.Count -gt 0) { $lines.Add(("    Connections: {0}" -f ($candidate.Connections -join '; '))) | Out-Null }
+        if (@($candidate.Listening).Count -gt 0) { $lines.Add(("    Listening: {0}" -f (@($candidate.Listening) -join '; '))) | Out-Null }
+        if (@($candidate.Connections).Count -gt 0) { $lines.Add(("    Connections: {0}" -f (@($candidate.Connections) -join '; '))) | Out-Null }
       }
       'Script' {
         $lines.Add(("{0}) Script {1} (Flags={2}, Created={3:o})" -f $candidate.Id, $candidate.Path, $flags, $candidate.Created)) | Out-Null
@@ -447,9 +448,9 @@ function Build-AiRequest {
     [System.Collections.IEnumerable]$Processes,
     [System.Collections.IEnumerable]$Scripts
   )
-  $taskSummary = if ($Tasks -and $Tasks.Count -gt 0) { Build-CandidateSummaries -Candidates $Tasks -Prefix 'T' } else { 'None.' }
-  $processSummary = if ($Processes -and $Processes.Count -gt 0) { Build-CandidateSummaries -Candidates $Processes -Prefix 'P' } else { 'None.' }
-  $scriptSummary = if ($Scripts -and $Scripts.Count -gt 0) { Build-CandidateSummaries -Candidates $Scripts -Prefix 'S' } else { 'None.' }
+  $taskSummary = if ($Tasks -and @($Tasks).Count -gt 0) { Build-CandidateSummaries -Candidates $Tasks -Prefix 'T' } else { 'None.' }
+  $processSummary = if ($Processes -and @($Processes).Count -gt 0) { Build-CandidateSummaries -Candidates $Processes -Prefix 'P' } else { 'None.' }
+  $scriptSummary = if ($Scripts -and @($Scripts).Count -gt 0) { Build-CandidateSummaries -Candidates $Scripts -Prefix 'S' } else { 'None.' }
 
   $systemPrompt = @"
 You are a Windows malware hunter.
@@ -500,7 +501,7 @@ function Invoke-MalwareClassification {
     [System.Collections.IEnumerable]$Processes,
     [System.Collections.IEnumerable]$Scripts
   )
-  if ((-not $Tasks -or $Tasks.Count -eq 0) -and (-not $Processes -or $Processes.Count -eq 0) -and (-not $Scripts -or $Scripts.Count -eq 0)) {
+  if ((-not $Tasks -or @($Tasks).Count -eq 0) -and (-not $Processes -or @($Processes).Count -eq 0) -and (-not $Scripts -or @($Scripts).Count -eq 0)) {
     return ''
   }
 
@@ -688,7 +689,7 @@ function Invoke-MalwareAssessment {
   $processes = @(Get-ProcessCandidates)
   $scripts = @(Get-ScriptCandidates)
 
-  if (($tasks.Count + $processes.Count + $scripts.Count) -eq 0) {
+  if ((@($tasks).Count + @($processes).Count + @($scripts).Count) -eq 0) {
     return [pscustomobject]@{
       Tasks           = @()
       Processes       = @()
@@ -700,7 +701,7 @@ function Invoke-MalwareAssessment {
     }
   }
 
-  Write-Info ("Collected {0} suspicious tasks, {1} processes, {2} scripts" -f $tasks.Count, $processes.Count, $scripts.Count)
+  Write-Info ("Collected {0} suspicious tasks, {1} processes, {2} scripts" -f @($tasks).Count, @($processes).Count, @($scripts).Count)
 
   $aiResponse = ''
   try {
@@ -714,7 +715,7 @@ function Invoke-MalwareAssessment {
   $recommendations = if ($aiResponse) { Parse-AiRecommendations -ResponseText $aiResponse -Candidates $allCandidates } else { @{} }
 
   $removed = New-Object 'System.Collections.Generic.List[string]'
-  if ($Remove -and $recommendations.Count -gt 0) {
+  if ($Remove -and @($recommendations.Keys).Count -gt 0) {
     $deleteCandidates = @()
     foreach ($candidate in $allCandidates) {
       if (-not $candidate.Id) { continue }
@@ -723,7 +724,7 @@ function Invoke-MalwareAssessment {
       }
     }
 
-    if ($deleteCandidates.Count -gt 0) {
+    if (@($deleteCandidates).Count -gt 0) {
       Write-Host ''
       Write-Host 'AI suggested deleting the following items:'
       foreach ($candidate in $deleteCandidates) {
@@ -767,8 +768,9 @@ function Invoke-MalwareAssessment {
   $accessibility = @(Get-AccessibilityStatus)
   if ($Remove) {
     foreach ($status in $accessibility) {
-      if ($status.Issues.Count -eq 0) { continue }
-      $choice = Read-Host ("Restore {0}? (issues: {1}) [Y/N]" -f $status.Path, ($status.Issues -join ', '))
+      $issues = @($status.Issues)
+      if ($issues.Count -eq 0) { continue }
+      $choice = Read-Host ("Restore {0}? (issues: {1}) [Y/N]" -f $status.Path, ($issues -join ', '))
       if ([string]::IsNullOrWhiteSpace($choice)) { $choice = 'Y' }
       if ($choice.Trim().StartsWith('Y', [System.StringComparison]::OrdinalIgnoreCase)) {
         Restore-AccessibilityBinary -Status $status | Out-Null
@@ -789,7 +791,7 @@ function Invoke-MalwareAssessment {
 
 function Summarize-Recommendations {
   param($Result)
-  if (-not $Result -or $Result.Recommendations.Count -eq 0) { return 'No AI guidance available.' }
+  if (-not $Result -or @($Result.Recommendations).Count -eq 0) { return 'No AI guidance available.' }
   $delete = 0
   $review = 0
   foreach ($entry in $Result.Recommendations.GetEnumerator()) {
@@ -803,10 +805,10 @@ function Summarize-Recommendations {
 
 function Summarize-Accessibility {
   param($Statuses)
-  if (-not $Statuses -or $Statuses.Count -eq 0) { return 'Sticky keys binaries not evaluated.' }
-  $issues = $Statuses | Where-Object { $_.Issues.Count -gt 0 }
-  if (-not $issues -or $issues.Count -eq 0) { return 'Sticky keys binaries verified as Microsoft-signed.' }
-  $labels = $issues | ForEach-Object { "{0} ({1})" -f $_.Name, ($_.Issues -join ', ') }
+  if (-not $Statuses -or @($Statuses).Count -eq 0) { return 'Sticky keys binaries not evaluated.' }
+  $issues = $Statuses | Where-Object { @($_.Issues).Count -gt 0 }
+  if (-not $issues -or @($issues).Count -eq 0) { return 'Sticky keys binaries verified as Microsoft-signed.' }
+  $labels = $issues | ForEach-Object { $issueList = @($_.Issues); "{0} ({1})" -f $_.Name, ($issueList -join ', ') }
   return ('Sticky keys anomalies: ' + ($labels -join '; '))
 }
 
@@ -846,7 +848,8 @@ function Invoke-Apply {
   }
 
   $summary = Summarize-Recommendations -Result $result
-  $removedText = if ($result.Removed.Count -gt 0) { "Removed {0} item(s)." -f $result.Removed.Count } else { 'No items removed.' }
+  $removedCount = @($result.Removed).Count
+  $removedText = if ($removedCount -gt 0) { "Removed {0} item(s)." -f $removedCount } else { 'No items removed.' }
   $accessSummary = Summarize-Accessibility -Statuses $result.Accessibility
   $message = "$summary $removedText $accessSummary".Trim()
   if (-not $message) { $message = 'Malware persistence remediation completed.' }


### PR DESCRIPTION
## Summary
- normalize accessibility issue lists before checking counts in MalwarePersistence
- wrap other count usages with array coercion to avoid strict mode scalar errors and improve reporting text

## Testing
- Not run (PowerShell module changes only)


------
https://chatgpt.com/codex/tasks/task_e_69027235b26c83338c48e63fdbc02623