### PR TITLE
Fix README parser compatibility with Windows PowerShell

### DIFF
--- a/core/Parsing.psm1
+++ b/core/Parsing.psm1
@@ -20,17 +20,17 @@ function Remove-HTMLTags {
 function Find-RecentHireMentions {
   param(
     [string]$PlainText,
-    [System.Collections.Generic.HashSet[string]]$TerminatedSet = $(New-Object System.Collections.Generic.HashSet[string] ([StringComparer]::OrdinalIgnoreCase))
+    [System.Collections.Generic.HashSet[string]]$TerminatedSet = $(New-Object 'System.Collections.Generic.HashSet[string]' ([System.StringComparer]::OrdinalIgnoreCase))
   )
 
   $results = @()
   if (-not $PlainText) { return $results }
 
   if (-not $TerminatedSet) {
-    $TerminatedSet = New-Object System.Collections.Generic.HashSet[string] ([StringComparer]::OrdinalIgnoreCase)
+    $TerminatedSet = New-Object 'System.Collections.Generic.HashSet[string]' ([System.StringComparer]::OrdinalIgnoreCase)
   }
 
-  $seen = New-Object System.Collections.Generic.HashSet[string] ([StringComparer]::OrdinalIgnoreCase)
+  $seen = New-Object 'System.Collections.Generic.HashSet[string]' ([System.StringComparer]::OrdinalIgnoreCase)
   $sentences = [regex]::Split($PlainText, '(?<=[\.\?\!])\s+|\r?\n+')
   foreach ($sentence in $sentences) {
     $s = ($sentence -as [string]).Trim()
@@ -138,7 +138,7 @@ function Get-ReadmeInfo {
         $users  = @()
         $groups = @{}
         $terminatedRaw = @($doc.terminated_users) | Where-Object { $_ }
-        $terminatedSet = New-Object System.Collections.Generic.HashSet[string] ([StringComparer]::OrdinalIgnoreCase)
+        $terminatedSet = New-Object 'System.Collections.Generic.HashSet[string]' ([System.StringComparer]::OrdinalIgnoreCase)
         $terminated = @()
         foreach ($t in $terminatedRaw) {
           $name = ($t -as [string]).Trim()


### PR DESCRIPTION
## Summary
- update the README parser to use fully-qualified .NET types when creating hash sets
- ensure Windows PowerShell can load the parsing module so README parsing continues to work

## Testing
- not run (PowerShell is unavailable in the container)


------
https://chatgpt.com/codex/tasks/task_e_690280e5c3708333bc3e0a576bf9494c