### PR TITLE
Harden accessibility handling in malware persistence apply flow

### DIFF
--- a/modules/11_MalwarePersistence/MalwarePersistence.psm1
+++ b/modules/11_MalwarePersistence/MalwarePersistence.psm1
@@ -768,7 +768,7 @@ function Invoke-MalwareAssessment {
   $accessibility = @(Get-AccessibilityStatus)
   if ($Remove) {
     foreach ($status in $accessibility) {
-      $issues = @($status.Issues)
+      $issues = if ($null -ne $status -and $status.PSObject.Properties['Issues']) { @($status.Issues) } else { @() }
       if ($issues.Count -eq 0) { continue }
       $choice = Read-Host ("Restore {0}? (issues: {1}) [Y/N]" -f $status.Path, ($issues -join ', '))
       if ([string]::IsNullOrWhiteSpace($choice)) { $choice = 'Y' }
@@ -791,7 +791,7 @@ function Invoke-MalwareAssessment {
 
 function Summarize-Recommendations {
   param($Result)
-  if (-not $Result -or @($Result.Recommendations).Count -eq 0) { return 'No AI guidance available.' }
+  if (-not $Result -or @($Result.Recommendations.Keys).Count -eq 0) { return 'No AI guidance available.' }
   $delete = 0
   $review = 0
   foreach ($entry in $Result.Recommendations.GetEnumerator()) {


### PR DESCRIPTION
## Summary
- guard accessibility remediation loop against missing Issues properties before counting
- correct AI recommendation summary to evaluate recommendation keys rather than the hashtable itself

## Testing
- no automated tests were run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_69028310b80c8333b1427242a43f371d