### PR TITLE
Handle access denied when scanning for scripts

### DIFF
--- a/modules/11_MalwarePersistence/MalwarePersistence.psm1
+++ b/modules/11_MalwarePersistence/MalwarePersistence.psm1
@@ -407,12 +407,26 @@ function Get-ScriptCandidates {
   foreach ($root in $roots) {
     if (-not $root) { continue }
     if (-not (Test-Path -LiteralPath $root)) { continue }
+    $scanErrors = $null
     try {
-      $files = Get-ChildItem -LiteralPath $root -Recurse -File -ErrorAction Stop | Where-Object { $_.Extension -and ($script:ScriptExtensions -contains $_.Extension.ToLowerInvariant()) }
+      $files = Get-ChildItem -LiteralPath $root -Recurse -File -ErrorAction SilentlyContinue -ErrorVariable scanErrors
     } catch {
-      Write-Warn ("Failed to scan scripts under {0}: {1}" -f $root, $_.Exception.Message)
+      Write-Warn ("Failed to enumerate scripts under {0}: {1}" -f $root, $_.Exception.Message)
       continue
     }
+
+    if ($scanErrors) {
+      foreach ($err in $scanErrors) {
+        if ($err.FullyQualifiedErrorId -eq 'FileSystemError,Microsoft.PowerShell.Commands.GetChildItemCommand') {
+          # Access denied and similar filesystem errors are expected when crawling user profiles.
+          Write-Debug ("Skipped path during script scan under {0}: {1}" -f $root, $err.Exception.Message)
+        } else {
+          Write-Warn ("Issue encountered while scanning {0}: {1}" -f $root, $err.Exception.Message)
+        }
+      }
+    }
+
+    $files = $files | Where-Object { $_.Extension -and ($script:ScriptExtensions -contains $_.Extension.ToLowerInvariant()) }
     foreach ($file in $files) {
       $snippet = Get-FileSnippet -Path $file.FullName -LineCount $script:SnippetLineCount
       $flags = Get-ScriptFlags -Path $file.FullName -Head $snippet.Head -Tail $snippet.Tail


### PR DESCRIPTION
## Summary
- allow the MalwarePersistence script scanner to continue traversing user folders when access denied errors occur
- collect and log non-fatal traversal errors while still filtering candidate script extensions

## Testing
- npm test --silent

------
https://chatgpt.com/codex/tasks/task_e_690286b1edc883338ca2bf15c467ca0a