### PR TITLE
Fix placeholder regex options initialization

### DIFF
--- a/modules/14_Forensics/ForensicsQuestions.psm1
+++ b/modules/14_Forensics/ForensicsQuestions.psm1
@@ -14,9 +14,10 @@ $script:OpenRouterModel       = if ($env:OPENROUTER_MODEL) { $env:OPENROUTER_MOD
 $script:OpenRouterMaxTokens   = 6000
 $script:QuestionPattern       = 'Forensics Question *.txt'
 $script:PlaceholderPattern    = '^(?<indent>\s*)(?<prefix>ANSWER:\s*)(?<placeholder><Type Answer Here>)(?<suffix>\s*)$'
-$script:PlaceholderRegex      = New-Object System.Text.RegularExpressions.Regex(
+$script:PlaceholderRegexOptions = [System.Text.RegularExpressions.RegexOptions]'IgnoreCase, Multiline'
+$script:PlaceholderRegex        = [System.Text.RegularExpressions.Regex]::new(
   $script:PlaceholderPattern,
-  [System.Text.RegularExpressions.RegexOptions]::Multiline -bor [System.Text.RegularExpressions.RegexOptions]::IgnoreCase
+  $script:PlaceholderRegexOptions
 )
 $script:MaxCommandOutputBytes = 200 * 1024
 $script:MaxCommandRequests    = 6


### PR DESCRIPTION
## Summary
- replace the failing bitwise-or expression when building the placeholder regex options
- instantiate the placeholder regex with a precomputed flag combination to avoid array coercion errors on load

## Testing
- not run (not available in container)

------
https://chatgpt.com/codex/tasks/task_e_6902895933b48333a6e7c1acbcac80af