### PR TITLE
Fix AI service planning request body serialization

### DIFF
--- a/modules/06_ServiceAuditing/ServiceAuditing.psm1
+++ b/modules/06_ServiceAuditing/ServiceAuditing.psm1
@@ -80,7 +80,12 @@ Only output valid JSON for the directive object.
     )
   }
 
-  return ($body | ConvertTo-Json -Depth 6)
+  $json = $body | ConvertTo-Json -Depth 6
+  if ($json -is [System.Array]) {
+    $json = $json -join [Environment]::NewLine
+  }
+
+  return [string]$json
 }
 
 function Get-ServicePlanContentText {


### PR DESCRIPTION
## Summary
- ensure the AI service plan request body is serialized to a single JSON string before invoking the API

## Testing
- not run (environment lacks PowerShell)


------
https://chatgpt.com/codex/tasks/task_e_69029d98411c8333aeb0f628fd7faf37