### PR TITLE
Add OpenRouter headers and improve malware persistence AI error handling

### DIFF
--- a/modules/11_MalwarePersistence/MalwarePersistence.psm1
+++ b/modules/11_MalwarePersistence/MalwarePersistence.psm1
@@ -14,6 +14,8 @@ $script:ModuleName              = 'MalwarePersistence'
 $script:ApiUrl                  = 'https://openrouter.ai/api/v1/chat/completions'
 $script:ApiKeyEnvVar            = 'OPENROUTER_API_KEY'
 $script:AiModel                 = 'openai/gpt-5'
+$script:OpenRouterReferer       = 'https://github.com/cisagov/cp-win-auto'
+$script:OpenRouterClientTitle   = 'cp-win-auto MalwarePersistence module'
 
 # Tuning
 $script:RecentDaysThreshold     = 30
@@ -421,6 +423,12 @@ function Invoke-MalwareClassification {
       $wc = New-Object System.Net.WebClient
       $wc.Headers.Add('Authorization', "Bearer $apiKey")
       $wc.Headers.Add('Content-Type', 'application/json')
+      if ($script:OpenRouterReferer) {
+        try { $wc.Headers.Add('Referer', $script:OpenRouterReferer) } catch {}
+      }
+      if ($script:OpenRouterClientTitle) {
+        try { $wc.Headers.Add('X-Title', $script:OpenRouterClientTitle) } catch {}
+      }
       # Use UploadString which blocks until response returns
       $responseRaw = $null
       try {
@@ -428,12 +436,18 @@ function Invoke-MalwareClassification {
       } finally {
         $wc.Dispose()
       }
-      if (-not $responseRaw) { throw "Empty HTTP response on attempt $attempt" }
+      if ([string]::IsNullOrWhiteSpace($responseRaw)) { throw "Empty HTTP response on attempt $attempt" }
       # Parse JSON response
       $responseObj = $null
       try { $responseObj = $responseRaw | ConvertFrom-Json -ErrorAction Stop } catch { throw "Failed to parse JSON response: $($_.Exception.Message)" }
       # Expect structure: choices[0].message.content
       if ($null -eq $responseObj) { throw "OpenRouter returned no content (null object)." }
+      if ($responseObj | Get-Member -Name 'error' -MemberType NoteProperty -ErrorAction SilentlyContinue) {
+        $errorMessage = $null
+        try { $errorMessage = $responseObj.error.message } catch { $errorMessage = $null }
+        if (-not $errorMessage) { $errorMessage = $responseRaw }
+        throw ("OpenRouter error response: {0}" -f $errorMessage)
+      }
       if ($responseObj.choices -and $responseObj.choices.Count -gt 0 -and $responseObj.choices[0].message -and $responseObj.choices[0].message.content) {
         return $responseObj.choices[0].message.content.Trim()
       } else {


### PR DESCRIPTION
## Summary
- add application metadata headers to the OpenRouter chat completion request used by the malware persistence module
- treat blank HTTP bodies as errors and bubble up message details when the OpenRouter API returns an error payload

## Testing
- Not run (PowerShell not available in container)


------
https://chatgpt.com/codex/tasks/task_e_6903faafb51c8333a02e0b44fe51a911