### PR TITLE
Handle README user synonyms and surface AI output

### DIFF
--- a/modules/01_UserAuditing/UserAuditing.psm1
+++ b/modules/01_UserAuditing/UserAuditing.psm1
@@ -4,9 +4,7 @@ Set-StrictMode -Version Latest
 if (-not (Get-Command New-ModuleResult -EA SilentlyContinue)) {
   Import-Module -Force -DisableNameChecking (Join-Path $PSScriptRoot '../../core/Contracts.psm1')
 }
-if (-not (Get-Command Write-Info -EA SilentlyContinue)) {
-  Import-Module -Force -DisableNameChecking (Join-Path $PSScriptRoot '../../core/Utils.psm1')
-}
+Import-Module -Force -DisableNameChecking (Join-Path $PSScriptRoot '../../core/Utils.psm1')
 
 function Test-Ready { param($Context) return $true }
 


### PR DESCRIPTION
## Summary
- map README fields like new_hires and users_to_create into the recent_hires list that downstream logic consumes
- convert string-based user directives into structured records and echo the AI response to the console for visibility
- always import the shared Utils module within user auditing so helper functions are available

## Testing
- ⚠️ `pwsh -NoLogo -Command "Import-Module ./core/Parsing.psm1"` *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_6903fd0092fc8333b823d19d19ce4573