### PR TITLE
Fix OpenRouter call in malware persistence module

### DIFF
--- a/modules/11_MalwarePersistence/MalwarePersistence.psm1
+++ b/modules/11_MalwarePersistence/MalwarePersistence.psm1
@@ -412,60 +412,55 @@ function Invoke-MalwareClassification {
   if (-not $apiKey) { throw 'OpenRouter API key is missing; set the environment variable before running this module.' }
 
   $bodyJson = Build-AiRequest -Tasks $Tasks -Processes $Processes -Scripts $Scripts
-  $headers = @{ 'Authorization' = "Bearer $apiKey"; 'Content-Type' = 'application/json' }
+
+  $headers = @{
+    'Authorization' = "Bearer $apiKey"
+  }
+  if ($script:OpenRouterReferer) { $headers['Referer'] = $script:OpenRouterReferer }
+  if ($script:OpenRouterClientTitle) { $headers['X-Title'] = $script:OpenRouterClientTitle }
 
   $attempt = 0
   $lastError = $null
   while ($attempt -lt $MaxAttempts) {
     $attempt++
     try {
-      # Invoke synchronously; set a reasonable timeout via a webrequest timeout wrapper
-      $wc = New-Object System.Net.WebClient
-      $wc.Headers.Add('Authorization', "Bearer $apiKey")
-      $wc.Headers.Add('Content-Type', 'application/json')
-      if ($script:OpenRouterReferer) {
-        try { $wc.Headers.Add('Referer', $script:OpenRouterReferer) } catch {}
+      $invokeParams = @{
+        Uri         = $script:ApiUrl
+        Method      = 'Post'
+        Headers     = $headers
+        Body        = $bodyJson
+        ContentType = 'application/json'
+        ErrorAction = 'Stop'
       }
-      if ($script:OpenRouterClientTitle) {
-        try { $wc.Headers.Add('X-Title', $script:OpenRouterClientTitle) } catch {}
-      }
-      # Use UploadString which blocks until response returns
-      $responseRaw = $null
-      try {
-        $responseRaw = $wc.UploadString($script:ApiUrl, 'POST', $bodyJson)
-      } finally {
-        $wc.Dispose()
-      }
-      if ([string]::IsNullOrWhiteSpace($responseRaw)) { throw "Empty HTTP response on attempt $attempt" }
-      # Parse JSON response
-      $responseObj = $null
-      try { $responseObj = $responseRaw | ConvertFrom-Json -ErrorAction Stop } catch { throw "Failed to parse JSON response: $($_.Exception.Message)" }
-      # Expect structure: choices[0].message.content
+      if ($TimeoutSeconds -gt 0) { $invokeParams['TimeoutSec'] = $TimeoutSeconds }
+
+      $responseObj = Invoke-RestMethod @invokeParams
+
       if ($null -eq $responseObj) { throw "OpenRouter returned no content (null object)." }
       if ($responseObj | Get-Member -Name 'error' -MemberType NoteProperty -ErrorAction SilentlyContinue) {
         $errorMessage = $null
         try { $errorMessage = $responseObj.error.message } catch { $errorMessage = $null }
-        if (-not $errorMessage) { $errorMessage = $responseRaw }
+        if (-not $errorMessage) { $errorMessage = ($responseObj | ConvertTo-Json -Depth 6) }
         throw ("OpenRouter error response: {0}" -f $errorMessage)
       }
       if ($responseObj.choices -and $responseObj.choices.Count -gt 0 -and $responseObj.choices[0].message -and $responseObj.choices[0].message.content) {
-        return $responseObj.choices[0].message.content.Trim()
-      } else {
-        # If the response doesn't match expected shape, return the raw text for visibility
-        if ($responseObj | Get-Member -Name 'message' -MemberType NoteProperty -ErrorAction SilentlyContinue) {
-          return ($responseRaw)
-        }
-        throw "Unexpected response shape from OpenRouter (attempt $attempt)."
+        return ($responseObj.choices[0].message.content).Trim()
       }
+
+      if ($responseObj | Get-Member -Name 'message' -MemberType NoteProperty -ErrorAction SilentlyContinue) {
+        return ($responseObj | ConvertTo-Json -Depth 6)
+      }
+
+      throw "Unexpected response shape from OpenRouter (attempt $attempt)."
     } catch {
       $lastError = $_.Exception.Message
       Write-Warn ("OpenRouter attempt {0} failed: {1}" -f $attempt, $lastError)
       if ($attempt -lt $MaxAttempts) {
         Start-Sleep -Seconds (5 * $attempt)
         continue
-      } else {
-        throw ("OpenRouter failed after {0} attempts: {1}" -f $MaxAttempts, $lastError)
       }
+
+      throw ("OpenRouter failed after {0} attempts: {1}" -f $MaxAttempts, $lastError)
     }
   }
 


### PR DESCRIPTION
## Summary
- replace the MalwarePersistence OpenRouter request with Invoke-RestMethod to mirror the working modules
- preserve Referer and X-Title headers while improving error reporting when the response is malformed

## Testing
- not run (module change only)


------
https://chatgpt.com/codex/tasks/task_e_69050b559f84833399035054460840a5