### PR TITLE
Fix duplicated answer prefixes in forensic outputs

### DIFF
--- a/modules/14_Forensics/ForensicsQuestions.psm1
+++ b/modules/14_Forensics/ForensicsQuestions.psm1
@@ -202,6 +202,7 @@ function Clean-AnswerLine {
   param([string]$Line)
   if (-not $Line) { return '' }
   $value = $Line.Trim()
+  $value = $value -replace '^(?i)(final\s+answer\s*:|answer\s*:)', ''
   $value = $value -replace '^[\-\*\u2022]+\s*',''
   $value = $value -replace '^\d+[\.)]\s*',''
   return $value.Trim()


### PR DESCRIPTION
## Summary
- strip leading "FINAL ANSWER:"/"ANSWER:" labels when normalizing answer lines
- prevent duplicate prefixes from being written back into forensic question files

## Testing
- ⚠️ `pwsh -NoLogo -NoProfile -Command "Import-Module (Resolve-Path ./modules/14_Forensics/ForensicsQuestions.psm1)"` *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_6905178785788333acffa651eb9b3767