### PR TITLE
Fix OpenRouter handling in MalwarePersistence

### DIFF
--- a/modules/11_MalwarePersistence/MalwarePersistence.psm1
+++ b/modules/11_MalwarePersistence/MalwarePersistence.psm1
@@ -22,7 +22,7 @@ $script:RecentDaysThreshold     = 30
 $script:MaxTaskEntries          = 25
 $script:MaxProcessEntries       = 25
 # We only filter by extension under C:\Users (all subfolders). Cap number sent.
-$script:MaxScriptEntries        = 400
+$script:MaxScriptEntries        = 200
 $script:SnippetLineCount        = 40
 
 # Process/Task heuristics (still used)
@@ -389,6 +389,7 @@ $scriptSummary
     model       = $script:AiModel
     temperature = 0
     max_tokens  = 4000
+    response_format = @{ type = 'text' }
     messages    = @(
       @{ role = 'system'; content = $systemPrompt },
       @{ role = 'user';   content = $userPrompt }
@@ -415,6 +416,8 @@ function Invoke-MalwareClassification {
 
   $headers = @{
     'Authorization' = "Bearer $apiKey"
+    'Content-Type'  = 'application/json'
+    'Accept'        = 'application/json'
   }
   if ($script:OpenRouterReferer) { $headers['Referer'] = $script:OpenRouterReferer }
   if ($script:OpenRouterClientTitle) { $headers['X-Title'] = $script:OpenRouterClientTitle }
@@ -443,15 +446,51 @@ function Invoke-MalwareClassification {
         if (-not $errorMessage) { $errorMessage = ($responseObj | ConvertTo-Json -Depth 6) }
         throw ("OpenRouter error response: {0}" -f $errorMessage)
       }
-      if ($responseObj.choices -and $responseObj.choices.Count -gt 0 -and $responseObj.choices[0].message -and $responseObj.choices[0].message.content) {
-        return ($responseObj.choices[0].message.content).Trim()
+      $choice = $null
+      try {
+        if ($responseObj.choices) {
+          $choice = $responseObj.choices | Select-Object -First 1
+        }
+      } catch {}
+
+      $msg = $null
+      if ($choice -and (_HasProp $choice 'message')) { $msg = $choice.message }
+      elseif ($choice -is [string]) { $msg = $choice }
+
+      $content = $null
+      if ($null -ne $msg) {
+        $msgContent = $null
+        if (_HasProp $msg 'content') { $msgContent = $msg.content }
+        elseif ($msg -is [string]) { $msgContent = [string]$msg }
+
+        if ($msgContent -is [string]) {
+          $content = $msgContent
+        } elseif ($msgContent -is [System.Collections.IEnumerable] -and -not ($msgContent -is [string])) {
+          $segments = New-Object 'System.Collections.Generic.List[string]'
+          foreach ($seg in $msgContent) {
+            try {
+              $text = $null
+              if (_HasProp $seg 'text') { $text = $seg.text }
+              elseif ($seg -is [string]) { $text = $seg }
+              if (-not [string]::IsNullOrWhiteSpace($text)) { $segments.Add([string]$text) | Out-Null }
+            } catch {}
+          }
+          if ($segments.Count -gt 0) { $content = ($segments -join "`n") }
+        }
       }
 
-      if ($responseObj | Get-Member -Name 'message' -MemberType NoteProperty -ErrorAction SilentlyContinue) {
-        return ($responseObj | ConvertTo-Json -Depth 6)
+      if ($content -and -not [string]::IsNullOrWhiteSpace($content)) {
+        return $content.Trim()
       }
 
-      throw "Unexpected response shape from OpenRouter (attempt $attempt)."
+      if ($msg -and $msg.PSObject -and $msg.PSObject.Properties['tool_calls']) {
+        throw "Model returned tool_calls with no assistant text (unsupported by this module)."
+      }
+
+      $raw = ''
+      try { $raw = $responseObj | ConvertTo-Json -Depth 6 } catch {}
+      if ($raw.Length -gt 1000) { $raw = $raw.Substring(0, 1000) }
+      throw ("Assistant content was empty/whitespace. Raw response (truncated): {0}" -f $raw)
     } catch {
       $lastError = $_.Exception.Message
       Write-Warn ("OpenRouter attempt {0} failed: {1}" -f $attempt, $lastError)
@@ -688,7 +727,12 @@ function Invoke-MalwareAssessment {
   if ($Remove) {
     foreach ($status in $accessibility) {
       $issues = if (_HasProp $status 'Issues') { $status.Issues } else { @() }
-      if (_Count($issues) -eq 0) { continue }
+      $issueCount =
+        if ($issues -is [System.Array]) { $issues.Length }
+        elseif ($issues -is [string]) { if ([string]::IsNullOrWhiteSpace($issues)) { 0 } else { 1 } }
+        else { _Count($issues) }
+
+      if ($issueCount -eq 0) { continue }
       $issueText = (_JoinSemis $issues)
       $choice = Read-Host ("Restore {0}? (issues: {1}) [Y/N]" -f $status.Path, $issueText)
       if ([string]::IsNullOrWhiteSpace($choice)) { $choice = 'Y' }


### PR DESCRIPTION
## Summary
- add response_format metadata and standard headers to MalwarePersistence OpenRouter requests to keep responses in plain text
- harden assistant response parsing to support segmented content and emit diagnostics when the assistant reply is empty
- trim the number of script candidates shared with the model and avoid sticky-keys restore prompts when no issues are present

## Testing
- _No automated tests were run (PowerShell is unavailable in container)_

------
https://chatgpt.com/codex/tasks/task_e_69052470f87083339d9b486737122858