### PR TITLE
Rewrite malware persistence module for AI-based script triage

### DIFF
--- a/modules/11_MalwarePersistence/MalwarePersistence.psm1
+++ b/modules/11_MalwarePersistence/MalwarePersistence.psm1
@@ -1,11 +1,5 @@
 Set-StrictMode -Version Latest
-#Requires -Version 5.1
 
-# =========================================================
-# MalwarePersistence.psm1 (rewritten with robust AI handling & verbose logging)
-# =========================================================
-
-# ----------------- Imports / Shared -----------------
 if (-not (Get-Command New-ModuleResult -EA SilentlyContinue)) {
   Import-Module -Force -DisableNameChecking (Join-Path $PSScriptRoot '../../core/Contracts.psm1')
 }
@@ -13,832 +7,268 @@ if (-not (Get-Command Write-Info -EA SilentlyContinue)) {
   Import-Module -Force -DisableNameChecking (Join-Path $PSScriptRoot '../../core/Utils.psm1')
 }
 
-# ----------------- Module Settings -----------------
-$script:ModuleName              = 'MalwarePersistence'
-$script:ApiUrl                  = 'https://openrouter.ai/api/v1/chat/completions'
-$script:ApiKeyEnvVar            = 'OPENROUTER_API_KEY'
-$script:AiModel                 = 'openai/gpt-5'
-$script:OpenRouterReferer       = 'https://github.com/cisagov/cp-win-auto'
-$script:OpenRouterClientTitle   = 'cp-win-auto MalwarePersistence module'
+$script:ModuleName       = 'MalwarePersistence'
+$script:ApiUrl           = 'https://openrouter.ai/api/v1/chat/completions'
+$script:ApiKeyEnvVar     = 'OPENROUTER_API_KEY'
+$script:ScanDirectories  = @('C:\\Users', 'C:\\ProgramData', 'C:\\Program Files', 'C:\\Program Files (x86)')
+$script:ScriptExtensions = @('.ps1','.psm1','.bat','.cmd','.vbs','.js','.jse','.hta','.py')
 
-# Tuning
-$script:RecentDaysThreshold     = 30
-$script:MaxTaskEntries          = 25
-$script:MaxProcessEntries       = 25
-# Reduced for reliability (was 400)
-$script:MaxScriptEntries        = 200
-$script:SnippetLineCount        = 40
-
-# Process/Task heuristics
-$script:InterpreterNames        = @('powershell.exe','pwsh.exe','cmd.exe','wscript.exe','cscript.exe','mshta.exe','python.exe','rundll32.exe','regsvr32.exe')
-$script:SuspiciousCommandFlags  = @(
-  @{ Pattern = '(?i)-(enc|encodedcommand)'; Flag = 'EncodedCommand' },
-  @{ Pattern = '(?i)\b(-|/)(e|ec|exec|l|lv|lvp)\b'; Flag = 'ShellSwitch' },
-  @{ Pattern = '(?i)\bno(p|profile)\b'; Flag = 'NoProfile' },
-  @{ Pattern = '(?i)hidden'; Flag = 'HiddenWindow' },
-  @{ Pattern = '(?i)mimikatz|sekurlsa'; Flag = 'CredentialTheft' },
-  @{ Pattern = '(?i)ntdsutil|ntds\.dit'; Flag = 'NTDS' },
-  @{ Pattern = '(?i)reverse\s*tcp|bind\s*shell'; Flag = 'ReverseShell' }
-)
-
-# File types treated as scripts (extension-only filter for C:\Users\)
-$script:ScriptExtensions        = @('.ps1','.psm1','.bat','.cmd','.vbs','.js','.jse','.hta','.py')
-
-# Accessibility binaries (sticky keys)
-$script:AccessibilityBinaries   = @('sethc.exe','utilman.exe','osk.exe')
-
-# Path heuristics for tasks/processes
-$script:SuspiciousPathPrefixes  = @('c:\users\','c:\programdata\','c:\public\','c:\inetpub\','c:\windows\temp\')
-$script:SuspiciousPathKeywords  = @('\downloads\','\appdata\','\temp\','\startup\','\start menu\programs\startup\')
-
-# ----------------- Always-On Verbose Logging -----------------
-function Log-Verbose { param([string]$Message)
-  try {
-    if ([string]::IsNullOrWhiteSpace($Message)) { return }
-    $ts = (Get-Date).ToString('yyyy-MM-dd HH:mm:ss.fff')
-    Write-Host ("[VERBOSE] [$ts] {0}" -f $Message)
-  } catch {
-    # swallow, avoid breaking module
-  }
-}
-
-# ----------------- Helpers -----------------
 function Get-OpenRouterApiKey {
   $key = [System.Environment]::GetEnvironmentVariable($script:ApiKeyEnvVar)
   if (-not $key) { return '' }
   return $key
 }
-function _HasProp($obj, [string]$name) {
-  return ($null -ne $obj -and $null -ne $obj.PSObject -and $null -ne $obj.PSObject.Properties[$name])
-}
-function _Count($x) {
-  if ($null -eq $x) { return 0 }
-  if ($x -is [string]) { if ([string]::IsNullOrEmpty($x)) { return 0 } else { return 1 } }
-  if ($x -is [System.Array]) { return $x.Length }
-  if ($x -is [System.Collections.ICollection]) { return $x.Count }
-  try { $p = $x.PSObject.Properties['Count']; if ($p) { return [int]$p.Value } } catch {}
-  try { return @($x).Count } catch {}
-  return 0
-}
-function _JoinSemis($x) {
-  $arr = @()
-  if ($null -ne $x) {
-    if ($x -is [System.Collections.IEnumerable] -and -not ($x -is [string])) { $arr = @($x) } else { $arr = @($x) }
+
+function Test-Ready {
+  param($Context)
+
+  if (-not (Get-OpenRouterApiKey)) {
+    Write-Warn "OpenRouter API key is missing (set `$env:$($script:ApiKeyEnvVar)); cannot classify suspicious scripts."
+    return $false
   }
-  return ($arr -join '; ')
-}
-function Normalize-Path { param([string]$Path)
-  if ([string]::IsNullOrWhiteSpace($Path)) { return '' }
-  $normalized = $Path.Trim().Trim(@([char]34,[char]39))
-  $normalized = $normalized -replace '[\\/]+', '\'
-  return $normalized
-}
-function Test-IsSuspiciousPath { param([string]$Path)
-  $normalized = Normalize-Path -Path $Path
-  if (-not $normalized) { return $false }
-  $lower = $normalized.ToLowerInvariant()
-  foreach ($p in $script:SuspiciousPathPrefixes) { if ($lower.StartsWith($p)) { return $true } }
-  foreach ($k in $script:SuspiciousPathKeywords) { if ($lower.Contains($k)) { return $true } }
-  return $false
-}
-function Test-IsRecentDirectory { param([string]$Path)
-  if (-not $Path) { return $false }
-  try {
-    $normalized = Normalize-Path -Path $Path
-    if (-not $normalized) { return $false }
-    $expanded = [Environment]::ExpandEnvironmentVariables($normalized)
-    if ([string]::IsNullOrWhiteSpace($expanded)) { return $false }
-    $directory = Split-Path -LiteralPath $expanded -Parent -ErrorAction Stop
-    if (-not $directory) { return $false }
-    if (-not (Test-Path -LiteralPath $directory -EA Stop)) { return $false }
-    $dirInfo = Get-Item -LiteralPath $directory -EA Stop
-    $age = (Get-Date) - $dirInfo.CreationTime
-    return ($age.TotalDays -le $script:RecentDaysThreshold)
-  } catch { return $false }
-}
-function Get-CommandFlags { param([string]$CommandLine)
-  $flags = New-Object 'System.Collections.Generic.List[string]'
-  if (-not $CommandLine) { return $flags }
-  foreach ($entry in $script:SuspiciousCommandFlags) {
-    if ($CommandLine -match $entry.Pattern) { $flags.Add($entry.Flag) | Out-Null }
-  }
-  return $flags
-}
-function Test-IsInterpreterUsage { param([string]$Executable,[string]$CommandLine)
-  $exeName = ''
-  try { if ($Executable) { $exeName = [System.IO.Path]::GetFileName($Executable) } } catch { $exeName = '' }
-  if ($exeName -and ($script:InterpreterNames -contains $exeName.ToLowerInvariant())) { return $true }
-  if ($CommandLine -and ($CommandLine -match '(?i)\b(powershell|pwsh|cmd|wscript|cscript|mshta|python|rundll32|regsvr32)\b')) { return $true }
-  return $false
-}
-function Convert-TriggerSummary { param($Triggers)
-  if (-not $Triggers) { return '' }
-  $items = New-Object 'System.Collections.Generic.List[string]'
-  foreach ($t in $Triggers) { try { $text = $t.ToString(); if ($text) { $items.Add($text.Trim()) | Out-Null } } catch {} }
-  return ($items -join '; ')
+
+  return $true
 }
 
-# ----------------- Scheduled Tasks -----------------
-function Get-TaskCandidates {
-  $tasks = @()
-  try { $tasks = Get-ScheduledTask -EA Stop } catch {
-    Write-Warn ("Failed to enumerate scheduled tasks: {0}" -f $_.Exception.Message)
-    return @()
-  }
-  $results = New-Object 'System.Collections.Generic.List[object]'
-  foreach ($task in $tasks) {
-    if (-not $task.Actions) { continue }
-    foreach ($action in $task.Actions) {
-      $execute = $null; $arguments = $null
-      try { $execute = $action.Execute; $arguments = $action.Arguments } catch { continue }
-      $commandLine = if ($arguments) { "`"$execute`" $arguments" } else { "`"$execute`"" }
-      $isSuspiciousPath = Test-IsSuspiciousPath -Path $execute
-      $flags = Get-CommandFlags -CommandLine $commandLine
-      $isInterpreter = Test-IsInterpreterUsage -Executable $execute -CommandLine $commandLine
-      $isRecentFolder = Test-IsRecentDirectory -Path $execute
+function Get-ScriptInventory {
+  $collected = New-Object 'System.Collections.Generic.List[string]'
 
-      $registrationDate = $null; $registrationFlag = $false
-      try {
-        $rawDate = $task.RegistrationInfo.Date
-        if ($rawDate) {
-          if ([DateTime]::TryParse($rawDate, [ref]$registrationDate)) {
-            if (((Get-Date) - $registrationDate).TotalDays -le $script:RecentDaysThreshold) { $registrationFlag = $true }
-          }
-        }
-      } catch { $registrationDate = $null }
-
-      if (-not ($isSuspiciousPath -or $isInterpreter -or $registrationFlag -or $isRecentFolder -or (_Count($flags) -gt 0))) { continue }
-
-      $flagSet = New-Object 'System.Collections.Generic.List[string]'
-      if ($isSuspiciousPath) { $flagSet.Add('SuspiciousPath') | Out-Null }
-      if ($isInterpreter)    { $flagSet.Add('InterpreterLaunch') | Out-Null }
-      foreach ($f in $flags) { if ($f) { $flagSet.Add($f) | Out-Null } }
-      if ($isRecentFolder)   { $flagSet.Add('RecentFolder') | Out-Null }
-      if ($registrationFlag) { $flagSet.Add('RecentlyRegistered') | Out-Null }
-      if ($task.Principal -and $task.Principal.RunLevel -eq 'Highest') { $flagSet.Add('RunsHighestPrivileges') | Out-Null }
-
-      $triggerSummary = Convert-TriggerSummary -Triggers $task.Triggers
-      $results.Add([pscustomobject]@{
-        Type             = 'Task'
-        Name             = $task.TaskName
-        TaskPath         = $task.TaskPath
-        FullName         = ("{0}{1}" -f $task.TaskPath, $task.TaskName)
-        ActionPath       = $execute
-        Arguments        = $arguments
-        RunAsUser        = $task.Principal.UserId
-        TriggerSummary   = $triggerSummary
-        RegistrationDate = $registrationDate
-        Flags            = $flagSet.ToArray()
-        CommandLine      = $commandLine
-      }) | Out-Null
-    }
-  }
-  return @($results | Select-Object -First $script:MaxTaskEntries)
-}
-
-# ----------------- Processes -----------------
-function Get-ProcessConnectionMap {
-  $map = @{}
-  try { $connections = Get-NetTCPConnection -EA Stop } catch { return $map }
-  foreach ($conn in $connections) {
-    $pid = $conn.OwningProcess
-    if (-not $pid) { continue }
-    if (-not $map.ContainsKey($pid)) {
-      $map[$pid] = [pscustomobject]@{ Listening = New-Object 'System.Collections.Generic.List[string]'; Established = New-Object 'System.Collections.Generic.List[string]' }
-    }
-    $entry = $map[$pid]
-    $representation = ''
-    try {
-      $local  = "{0}:{1}" -f $conn.LocalAddress, $conn.LocalPort
-      $remote = if ($conn.RemoteAddress -and $conn.RemotePort) { "{0}:{1}" -f $conn.RemoteAddress, $conn.RemotePort } else { '' }
-      $representation = if ($remote) { "{0} -> {1} ({2})" -f $local, $remote, $conn.State } else { "{0} ({1})" -f $local, $conn.State }
-    } catch { $representation = '' }
-    if ($conn.State -eq 'Listen') {
-      if ($representation) { $entry.Listening.Add($representation) | Out-Null }
-    } elseif ($representation) {
-      $entry.Established.Add($representation) | Out-Null
-    }
-  }
-  return $map
-}
-function Get-SignatureStatus { param([string]$Path)
-  if (-not $Path) { return 'Unknown' }
-  if (-not (Test-Path -LiteralPath $Path)) { return 'Missing' }
-  try { $signature = Get-AuthenticodeSignature -FilePath $Path -EA Stop } catch { return 'Unknown' }
-  if (-not $signature) { return 'Unknown' }
-  if ($signature.Status -eq 'Valid' -and $signature.SignerCertificate) {
-    $subject = $signature.SignerCertificate.Subject
-    if ($subject -and ($subject -match 'Microsoft')) { return 'Microsoft' }
-    return 'Signed'
-  }
-  if ($signature.Status -eq 'NotSigned') { return 'Unsigned' }
-  return $signature.Status.ToString()
-}
-function Get-ProcessCandidates {
-  $processes = @()
-  try { $processes = Get-CimInstance -ClassName Win32_Process -EA Stop } catch {
-    Write-Warn ("Failed to enumerate processes: {0}" -f $_.Exception.Message)
-    return @()
-  }
-  $connectionMap = Get-ProcessConnectionMap
-  $results = New-Object 'System.Collections.Generic.List[object]'
-  foreach ($proc in $processes) {
-    $path = $proc.ExecutablePath
-    $commandLine = $proc.CommandLine
-    $creationTime = $null
-    try { if ($proc.CreationDate) { $creationTime = [System.Management.ManagementDateTimeConverter]::ToDateTime($proc.CreationDate) } } catch { $creationTime = $null }
-
-    $isSuspiciousPath = Test-IsSuspiciousPath -Path $path
-    $isRecentDir      = Test-IsRecentDirectory -Path $path
-    $flags            = Get-CommandFlags -CommandLine $commandLine
-    $isInterpreter    = Test-IsInterpreterUsage -Executable $path -CommandLine $commandLine
-
-    $connections = if ($connectionMap.ContainsKey($proc.ProcessId)) { $connectionMap[$proc.ProcessId] } else { $null }
-    $listening   = if ($connections) { $connections.Listening.ToArray() } else { @() }
-    $established = if ($connections) { $connections.Established.ToArray() } else { @() }
-
-    $shouldKeep = $isSuspiciousPath -or $isInterpreter -or $isRecentDir -or (_Count($flags) -gt 0) -or (_Count($listening) -gt 0)
-    if (-not $shouldKeep) { continue }
-
-    $flagSet = New-Object 'System.Collections.Generic.List[string]'
-    if ($isSuspiciousPath) { $flagSet.Add('SuspiciousPath') | Out-Null }
-    if ($isInterpreter)    { $flagSet.Add('InterpreterProcess') | Out-Null }
-    foreach ($f in $flags) { if ($f) { $flagSet.Add($f) | Out-Null } }
-    if ($isRecentDir)      { $flagSet.Add('RecentFolder') | Out-Null }
-    if (_Count($listening) -gt 0) { $flagSet.Add('ListeningPort') | Out-Null }
-
-    $signatureStatus = Get-SignatureStatus -Path $path
-
-    $results.Add([pscustomobject]@{
-      Type        = 'Process'
-      Name        = $proc.Name
-      ProcessId   = $proc.ProcessId
-      Path        = $path
-      CommandLine = $commandLine
-      StartTime   = $creationTime
-      Flags       = $flagSet.ToArray()
-      Signature   = $signatureStatus
-      Listening   = $listening
-      Connections = $established
-    }) | Out-Null
-  }
-  return @($results | Sort-Object { $_.StartTime } -Descending | Select-Object -First $script:MaxProcessEntries)
-}
-
-# ----------------- Scripts (EXTENSION-ONLY under C:\Users) -----------------
-function Get-UserScriptRoots {
-  $roots = New-Object 'System.Collections.Generic.List[string]'
-  if (Test-Path 'C:\Users') { $roots.Add('C:\Users') | Out-Null }
-  return ($roots | Sort-Object -Unique)
-}
-function Get-ScriptCandidates {
-  $roots = @(Get-UserScriptRoots)
-  $results = New-Object 'System.Collections.Generic.List[object]'
-
-  foreach ($root in $roots) {
-    if (-not $root) { continue }
+  foreach ($root in $script:ScanDirectories) {
+    if ([string]::IsNullOrWhiteSpace($root)) { continue }
     if (-not (Test-Path -LiteralPath $root)) { continue }
 
-    $scanErrors = $null
     try {
-      $files = Get-ChildItem -LiteralPath $root -Recurse -Force -EA SilentlyContinue -ErrorVariable scanErrors |
-        Where-Object { -not $_.PSIsContainer } |
-        Where-Object { $_.Extension -and ($script:ScriptExtensions -contains $_.Extension.ToLowerInvariant()) }
+      $items = Get-ChildItem -LiteralPath $root -File -Recurse -ErrorAction Stop
     } catch {
-      Write-Warn ("Failed to enumerate scripts under {0}: {1}" -f $root, $_.Exception.Message)
+      Write-Warn ("Failed to enumerate {0}: {1}" -f $root, $_.Exception.Message)
       continue
     }
 
-    if ($scanErrors) {
-      foreach ($err in $scanErrors) {
-        if ($err.FullyQualifiedErrorId -eq 'FileSystemError,Microsoft.PowerShell.Commands.GetChildItemCommand') {
-          Write-Debug ("Skipped path during script scan under {0}: {1}" -f $root, $err.Exception.Message)
-        } else {
-          Write-Warn ("Issue encountered while scanning {0}: {1}" -f $root, $err.Exception.Message)
+    foreach ($item in $items) {
+      try {
+        $ext = [System.IO.Path]::GetExtension($item.Name)
+      } catch {
+        $ext = ''
+      }
+
+      if (-not $ext) { continue }
+      $extLower = $ext.ToLowerInvariant()
+      if ($script:ScriptExtensions -contains $extLower) {
+        if (-not $collected.Contains($item.FullName)) {
+          $collected.Add($item.FullName) | Out-Null
         }
       }
     }
-
-    foreach ($file in $files) {
-      $results.Add([pscustomobject]@{
-        Type     = 'Script'
-        Path     = $file.FullName
-        Extension= $file.Extension.ToLowerInvariant()
-        Size     = $file.Length
-        Created  = $file.CreationTime
-        Modified = $file.LastWriteTime
-      }) | Out-Null
-    }
   }
 
-  $unique = $results | Sort-Object Path -Unique
-  $sorted = $unique | Sort-Object @{Expression='Modified';Descending=$true}, @{Expression='Created';Descending=$true}
-  return @($sorted | Select-Object -First $script:MaxScriptEntries)
-}
-
-# ----------------- Formatting & AI -----------------
-function Build-CandidateSummaries {
-  param([System.Collections.IEnumerable]$Candidates,[string]$Prefix)
-  $index = 1
-  $lines = New-Object 'System.Collections.Generic.List[string]'
-  foreach ($c in $Candidates) {
-    $c | Add-Member -NotePropertyName Id -NotePropertyValue ("{0}{1}" -f $Prefix, $index) -Force
-    switch ($c.Type) {
-      'Task' {
-        $flags = if (_HasProp $c 'Flags') { ($c.Flags -join ', ') } else { 'None' }
-        $lines.Add(("{0}) Task {1} (RunAs={2}, Flags={3})" -f $c.Id, $c.FullName, $c.RunAsUser, $flags)) | Out-Null
-        $lines.Add(("    Action: {0}" -f $c.CommandLine)) | Out-Null
-      }
-      'Process' {
-        $flags = if (_HasProp $c 'Flags') { ($c.Flags -join ', ') } else { 'None' }
-        $start = if ($c.StartTime) { $c.StartTime.ToString('o') } else { 'Unknown' }
-        $lines.Add(("{0}) Proc {1} (PID={2}, Signer={3}, Flags={4})" -f $c.Id, $c.Name, $c.ProcessId, $c.Signature, $flags)) | Out-Null
-        $lines.Add(("    Path: {0}" -f $c.Path)) | Out-Null
-      }
-      'Script' {
-        $lines.Add(("{0}) Script {1} (Ext={2}, Size={3} bytes, Modified={4:o})" -f $c.Id, $c.Path, $c.Extension, $c.Size, $c.Modified)) | Out-Null
-      }
-    }
-    $index++
-  }
-  return $lines -join [Environment]::NewLine
+  $unique = $collected | Sort-Object -Unique
+  return @($unique)
 }
 
 function Build-AiRequest {
-  param([System.Collections.IEnumerable]$Tasks,[System.Collections.IEnumerable]$Processes,[System.Collections.IEnumerable]$Scripts)
-
-  $taskSummary    = if ($Tasks    -and (_Count($Tasks)    -gt 0)) { Build-CandidateSummaries -Candidates $Tasks    -Prefix 'T' } else { 'None.' }
-  $processSummary = if ($Processes -and (_Count($Processes) -gt 0)) { Build-CandidateSummaries -Candidates $Processes -Prefix 'P' } else { 'None.' }
-  $scriptSummary  = if ($Scripts  -and (_Count($Scripts)  -gt 0)) { Build-CandidateSummaries -Candidates $Scripts  -Prefix 'S' } else { 'None.' }
+  param([string[]]$Inventory)
 
   $systemPrompt = @"
-You are a Windows malware hunter.
-You will receive:
-- A small set of scheduled tasks and running processes pre-filtered for suspicious characteristics, and
-- A list of script-like files found UNDER C:\Users\ (all subfolders), filtered ONLY by file extension
-  (extensions: $($script:ScriptExtensions -join ', ')).
-
-Identify items that are clearly malicious or unwanted in a CyberPatriot setting.
-Be conservative—if unsure, mark for human review rather than deletion.
-Return a short list of what to DELETE (with IDs) and a short list for MANUAL REVIEW. Keep it minimal and actionable.
+You are a Windows incident response assistant for CyberPatriot scoring.
+Return ONLY a raw JSON array (no code fences) of absolute filesystem paths for script files that are malicious or suspicious persistence mechanisms which should be removed.
+Only mark files that are clearly malicious, suspicious persistence, or not required for legitimate software operation.
+If no files require removal, respond with [].
 "@
 
+  $inventoryBlock = ($Inventory -join [Environment]::NewLine)
   $userPrompt = @"
-Each item includes an ID (T#, P#, S#). Reference these IDs in your recommendations.
+You are reviewing script files collected from persistence-prone directories on a Windows system.
 
-SCHEDULED TASKS:
-$taskSummary
+SCANNED FILES ($($Inventory.Count) entries):
+$inventoryBlock
 
-PROCESSES:
-$processSummary
-
-SCRIPTS (extension-only filter under C:\Users\):
-$scriptSummary
+Identify the files that are malicious or suspicious and should be removed. Respond ONLY with a JSON array of paths.
 "@
 
   $body = @{
-    model           = $script:AiModel
-    temperature     = 0
-    max_tokens      = 4000
-    # Force simple text, avoid tool_calls & segmented content surprises
-    response_format = @{ type = 'text' }
-    messages        = @(
+    model       = 'openai/gpt-5'
+    temperature = 0
+    max_tokens  = 4000
+    messages    = @(
       @{ role = 'system'; content = $systemPrompt },
-      @{ role = 'user';   content = $userPrompt }
+      @{ role = 'user'; content = $userPrompt }
     )
   }
 
-  $json = $body | ConvertTo-Json -Depth 6
-  Log-Verbose ("AI request built. Model='{0}', BodyLength={1} chars" -f $script:AiModel, $json.Length)
-  Log-Verbose ("AI user prompt preview (first 600 chars):`n{0}" -f (($userPrompt -replace '\s+', ' ') | Select-Object -First 1).Substring(0, [Math]::Min(600, $userPrompt.Length)))
-  return $json
+  return $body | ConvertTo-Json -Depth 6
 }
 
-# ----------------- AI (synchronous with retries + timeout) -----------------
-function Invoke-MalwareClassification {
-  param(
-    [System.Collections.IEnumerable]$Tasks,
-    [System.Collections.IEnumerable]$Processes,
-    [System.Collections.IEnumerable]$Scripts,
-    [int]$TimeoutSeconds = 120,
-    [int]$MaxAttempts = 3
-  )
+function Invoke-Classification {
+  param([string[]]$Inventory)
 
-  if ( (_Count($Tasks) -eq 0) -and (_Count($Processes) -eq 0) -and (_Count($Scripts) -eq 0) ) { return '' }
+  if (-not $Inventory -or $Inventory.Count -eq 0) {
+    return @()
+  }
+
+  $bodyJson = Build-AiRequest -Inventory $Inventory
+
   $apiKey = Get-OpenRouterApiKey
-  if (-not $apiKey) { throw 'OpenRouter API key is missing; set the environment variable before running this module.' }
-
-  $bodyJson = Build-AiRequest -Tasks $Tasks -Processes $Processes -Scripts $Scripts
+  if (-not $apiKey) {
+    throw 'OpenRouter API key was not available when classification was attempted.'
+  }
 
   $headers = @{
     'Authorization' = "Bearer $apiKey"
     'Content-Type'  = 'application/json'
-    'Accept'        = 'application/json'
-  }
-  if ($script:OpenRouterReferer)     { $headers['Referer'] = $script:OpenRouterReferer }
-  if ($script:OpenRouterClientTitle) { $headers['X-Title'] = $script:OpenRouterClientTitle }
-
-  $attempt = 0
-  $lastError = $null
-  while ($attempt -lt $MaxAttempts) {
-    $attempt++
-    Log-Verbose ("OpenRouter attempt {0}/{1}..." -f $attempt, $MaxAttempts)
-    try {
-      $invokeParams = @{
-        Uri         = $script:ApiUrl
-        Method      = 'Post'
-        Headers     = $headers
-        Body        = $bodyJson
-        ContentType = 'application/json'
-        ErrorAction = 'Stop'
-      }
-      if ($TimeoutSeconds -gt 0) { $invokeParams['TimeoutSec'] = $TimeoutSeconds }
-
-      $responseObj = Invoke-RestMethod @invokeParams
-      if ($null -eq $responseObj) { throw "OpenRouter returned no content (null object)." }
-
-      # Quick diagnostics of top-level shape
-      $hasChoices = ($responseObj | Get-Member -Name 'choices' -MemberType NoteProperty -ErrorAction SilentlyContinue)
-      $hasError   = ($responseObj | Get-Member -Name 'error'   -MemberType NoteProperty -ErrorAction SilentlyContinue)
-      Log-Verbose ("OpenRouter response keys: {0}" -f (($responseObj.PSObject.Properties.Name) -join ', '))
-
-      if ($hasError) {
-        $errorMessage = $null
-        try { $errorMessage = $responseObj.error.message } catch { $errorMessage = $null }
-        if (-not $errorMessage) { $errorMessage = ($responseObj | ConvertTo-Json -Depth 6) }
-        throw ("OpenRouter error response: {0}" -f $errorMessage)
-      }
-
-      if ($hasChoices -and $responseObj.choices -and $responseObj.choices.Count -gt 0) {
-        $choice = $responseObj.choices | Select-Object -First 1
-        $msg    = $choice.message
-        $content = $null
-
-        if ($null -ne $msg) {
-          # Many providers now return content as array of segments
-          if ($msg.content -is [string]) {
-            $content = $msg.content
-          } elseif ($msg.content -is [System.Collections.IEnumerable]) {
-            $segments = New-Object 'System.Collections.Generic.List[string]'
-            foreach ($seg in $msg.content) {
-              try {
-                if ($seg -is [string]) {
-                  $segments.Add([string]$seg) | Out-Null
-                } elseif ($seg.PSObject.Properties['text']) {
-                  $segments.Add([string]$seg.text) | Out-Null
-                } elseif ($seg.PSObject.Properties['type'] -and $seg.type -eq 'output_text' -and $seg.PSObject.Properties['text']) {
-                  $segments.Add([string]$seg.text) | Out-Null
-                }
-              } catch {}
-            }
-            $content = ($segments -join "`n")
-          }
-
-          # If we got tool_calls but no text, note it
-          if ([string]::IsNullOrWhiteSpace($content) -and $msg.PSObject.Properties['tool_calls']) {
-            Log-Verbose "Model returned tool_calls with no assistant text. This module ignores tool calls."
-          }
-        }
-
-        if ($content -and -not [string]::IsNullOrWhiteSpace($content)) {
-          $preview = $content.Substring(0, [Math]::Min(200, $content.Length)).Replace("`r"," ").Replace("`n"," ")
-          Log-Verbose ("Assistant text received (first 200 chars): {0}" -f $preview)
-          return $content.Trim()
-        }
-
-        # As a last resort, check if the provider shoved text somewhere else
-        if ($responseObj.PSObject.Properties['message']) {
-          $fallback = ($responseObj.message | ConvertTo-Json -Depth 6)
-          if (-not [string]::IsNullOrWhiteSpace($fallback)) { return $fallback }
-        }
-
-        # Empty content -> treat as error with diagnostics
-        $raw = ''
-        try { $raw = $responseObj | ConvertTo-Json -Depth 6 } catch {}
-        $trunc = if ($raw) { $raw.Substring(0, [Math]::Min(2000, $raw.Length)) } else { '' }
-        throw ("Assistant content empty/whitespace. Raw (trunc): {0}" -f $trunc)
-      }
-
-      throw "Unexpected response shape from OpenRouter (no choices)."
-    } catch {
-      $lastError = $_.Exception.Message
-      Write-Warn ("OpenRouter attempt {0} failed: {1}" -f $attempt, $lastError)
-      if ($attempt -lt $MaxAttempts) {
-        $delay = (5 * $attempt)
-        Log-Verbose ("Retrying after {0}s..." -f $delay)
-        Start-Sleep -Seconds $delay
-        continue
-      }
-      throw ("OpenRouter failed after {0} attempts: {1}" -f $MaxAttempts, $lastError)
-    }
   }
 
-  throw ("Invoke-MalwareClassification unexpected exit. Last error: {0}" -f $lastError)
-}
-
-function Parse-AiRecommendations {
-  param([string]$ResponseText,[System.Collections.IEnumerable]$Candidates)
-  $recommendations = @{}
-  foreach ($c in $Candidates) { if (_HasProp $c 'Id') { $recommendations[$c.Id] = [pscustomobject]@{ Recommendation='None'; Reason='' } } }
-  if (-not $ResponseText) { return $recommendations }
-
-  $lines = $ResponseText -split "`n"
-  foreach ($line in $lines) {
-    $trimmed = $line.Trim(); if (-not $trimmed) { continue }
-    foreach ($c in $Candidates) {
-      if (-not (_HasProp $c 'Id')) { continue }
-      if ($trimmed -notmatch [regex]::Escape($c.Id)) { continue }
-      $entry = $recommendations[$c.Id]
-      $lower = $trimmed.ToLowerInvariant()
-      $isDelete = ($lower -match 'delete|remove|quarantine|kill|terminate') -and ($lower -notmatch 'do not delete|keep')
-      $isReview = ($lower -match 'review|investigate|check|manual')
-      if ($isDelete) { $entry.Recommendation='Delete'; $entry.Reason=$trimmed }
-      elseif ($entry.Recommendation -ne 'Delete') {
-        if ($isReview -or $entry.Recommendation -eq 'None') { $entry.Recommendation='Review'; $entry.Reason=$trimmed }
-      }
-    }
-  }
-  return $recommendations
-}
-
-# ----------------- Quarantine / Remediation -----------------
-function Get-AccessibilityStatus {
-  $results = New-Object 'System.Collections.Generic.List[object]'
-  foreach ($binary in $script:AccessibilityBinaries) {
-    $path = Join-Path $env:windir (Join-Path 'System32' $binary)
-    $issues = New-Object 'System.Collections.Generic.List[string]'
-    $signature = 'Missing'
-    if ($path -and (Test-Path -LiteralPath $path)) {
-      $signature = Get-SignatureStatus -Path $path
-      if ($signature -ne 'Microsoft') { $issues.Add("SignatureStatus=$signature") | Out-Null }
-    } else { $issues.Add('FileMissing') | Out-Null }
-    $results.Add([pscustomobject]@{ Name=$binary; Path=$path; Signature=$signature; Issues=$issues.ToArray() }) | Out-Null
-  }
-  return $results
-}
-function Invoke-QuarantineFile { param([string]$Path)
-  if (-not $Path) { return $null }
-  if (-not (Test-Path -LiteralPath $Path)) { return $null }
   try {
-    $directory = Split-Path -Path $Path -Parent
-    $name = Split-Path -Path $Path -Leaf
-    $candidateName = "$name.quarantined"
-    $counter = 1
-    $target = Join-Path $directory $candidateName
-    while (Test-Path -LiteralPath $target) { $candidateName = "$name.quarantined$counter"; $target = Join-Path $directory $candidateName; $counter++ }
-    Rename-Item -LiteralPath $Path -NewName $candidateName -EA Stop
-    return $target
+    $response = Invoke-RestMethod -Uri $script:ApiUrl -Method Post -Headers $headers -Body $bodyJson -ErrorAction Stop
   } catch {
-    Write-Warn ("Failed to quarantine {0}: {1}" -f $Path, $_.Exception.Message)
-    return $null
+    throw ("OpenRouter API call failed: {0}" -f $_.Exception.Message)
   }
-}
-function Remove-TaskCandidate { param($Candidate)
+
+  $content = $response.choices[0].message.content
+  if (-not $content) {
+    throw 'OpenRouter returned an empty response.'
+  }
+
+  $content = $content -replace '^```json\s*', '' -replace '\s*```$',''
+
   try {
-    Unregister-ScheduledTask -TaskName $Candidate.Name -TaskPath $Candidate.TaskPath -Confirm:$false -EA Stop
-    Write-Info ("Removed scheduled task {0}" -f $Candidate.FullName)
-  } catch { Write-Warn ("Failed to remove task {0}: {1}" -f $Candidate.FullName, $_.Exception.Message) }
-  if (_HasProp $Candidate 'ActionPath') {
-    if ($Candidate.ActionPath -and (Test-IsSuspiciousPath -Path $Candidate.ActionPath) -and (Test-Path -LiteralPath $Candidate.ActionPath)) {
-      $q = Invoke-QuarantineFile -Path $Candidate.ActionPath
-      if ($q) { Write-Info ("Quarantined task payload {0}" -f $q) }
+    $parsed = $content | ConvertFrom-Json
+  } catch {
+    throw ("Failed to parse OpenRouter response: {0}" -f $_.Exception.Message)
+  }
+
+  if ($parsed -isnot [System.Collections.IEnumerable]) {
+    throw 'OpenRouter response was not an array.'
+  }
+
+  $paths = @()
+  foreach ($item in $parsed) {
+    if ($item -is [string]) {
+      $value = $item.Trim()
+      if ($value) { $paths += $value }
     }
   }
-}
-function Remove-ProcessCandidate { param($Candidate)
-  if (_HasProp $Candidate 'ProcessId') {
-    if ($Candidate.ProcessId) {
-      try { Stop-Process -Id $Candidate.ProcessId -Force -EA Stop; Write-Info ("Terminated process {0} (PID {1})" -f $Candidate.Name, $Candidate.ProcessId) }
-      catch { Write-Warn ("Failed to terminate PID {0}: {1}" -f $Candidate.ProcessId, $_.Exception.Message) }
-    }
-  }
-  if (_HasProp $Candidate 'Path') {
-    if ($Candidate.Path -and (Test-IsSuspiciousPath -Path $Candidate.Path) -and (Test-Path -LiteralPath $Candidate.Path)) {
-      $q = Invoke-QuarantineFile -Path $Candidate.Path
-      if ($q) { Write-Info ("Quarantined process binary {0}" -f $q) }
-    }
-  }
-}
-function Remove-ScriptCandidate { param($Candidate)
-  if (-not (_HasProp $Candidate 'Path')) { return }
-  if (-not $Candidate.Path) { return }
-  if (-not (Test-Path -LiteralPath $Candidate.Path)) { return }
-  $q = Invoke-QuarantineFile -Path $Candidate.Path
-  if ($q) { Write-Info ("Quarantined script {0}" -f $q) }
+
+  return @($paths | Sort-Object -Unique)
 }
 
-function Restore-AccessibilityBinary { param($Status)
-  if (-not (_HasProp $Status 'Path')) { return $false }
-  if (-not $Status.Path) { return $false }
-  $sfcPath = Join-Path $env:windir 'System32\sfc.exe'
-  if (-not (Test-Path -LiteralPath $sfcPath)) { Write-Warn 'sfc.exe not found; cannot attempt restoration.'; return $false }
-  try {
-    Write-Info ("Attempting SFC restore for {0}" -f $Status.Path)
-    $process = Start-Process -FilePath $sfcPath -ArgumentList ('/scanfile=""{0}""' -f $Status.Path) -Wait -PassThru -WindowStyle Hidden -EA Stop
-    if ($process.ExitCode -eq 0) { Write-Info ("SFC completed for {0}" -f $Status.Path); return $true }
-    Write-Warn ("SFC exited with code {0} for {1}" -f $process.ExitCode, $Status.Path)
-  } catch { Write-Warn ("Failed to run SFC for {0}: {1}" -f $Status.Path, $_.Exception.Message) }
-  return $false
-}
-
-# ----------------- Orchestration (interactive prompts retained) -----------------
 function Invoke-MalwareAssessment {
   param([switch]$Remove)
 
-  $tasks     = @(Get-TaskCandidates)
-  $processes = @(Get-ProcessCandidates)
-  $scripts   = @(Get-ScriptCandidates)   # EXTENSION-ONLY, C:\Users\ tree
+  Write-Info 'Enumerating potential persistence scripts'
+  $inventory = Get-ScriptInventory
+  $inventoryCount = $inventory.Count
+  Write-Info ("Collected {0} script file(s)" -f $inventoryCount)
 
-  Log-Verbose ("Collected candidates -> Tasks={0}, Processes={1}, Scripts={2}" -f (_Count $tasks), (_Count $processes), (_Count $scripts))
-
-  if ( (_Count($tasks) + _Count($processes) + _Count($scripts)) -eq 0 ) {
-    Log-Verbose "No candidates found; skipping AI triage."
+  if ($inventoryCount -eq 0) {
     return [pscustomobject]@{
-      Tasks           = @()
-      Processes       = @()
-      Scripts         = @()
-      Accessibility   = @(Get-AccessibilityStatus)
-      AiResponse      = ''
-      Recommendations = @{}
-      Removed         = @()
+      InventoryCount = 0
+      Flagged        = @()
+      Removed        = @()
+      Declined       = @()
     }
   }
 
-  Write-Info ("Collected {0} suspicious tasks, {1} processes, {2} scripts" -f (_Count($tasks)), (_Count($processes)), (_Count($scripts)))
+  Write-Info 'Requesting AI analysis from OpenRouter'
+  $flagged = Invoke-Classification -Inventory $inventory
 
-  $aiResponse = ''
-  try {
-    Write-Info 'Submitting snapshot to OpenRouter for triage (this will wait for the AI response)...'
-    $aiResponse = Invoke-MalwareClassification -Tasks $tasks -Processes $processes -Scripts $scripts -TimeoutSeconds 120 -MaxAttempts 3
-    if ($aiResponse) {
-      Write-Host ''
-      Write-Host '----- OpenRouter AI response (begin) -----'
-      Write-Host $aiResponse
-      Write-Host '----- OpenRouter AI response (end) -----'
-      Write-Host ''
-    } else {
-      Write-Warn 'OpenRouter returned an empty response.'
-    }
-  } catch {
-    Write-Warn ("AI classification failed: {0}" -f $_.Exception.Message)
-  }
-
-  $allCandidates = @($tasks + $processes + $scripts)
-  $recommendations = if ($aiResponse) { Parse-AiRecommendations -ResponseText $aiResponse -Candidates $allCandidates } else { @{} }
-
-  $removed = New-Object 'System.Collections.Generic.List[string]'
-
-  # If AI recommended deletes, prompt as before. If AI didn't recommend deletes, offer manual review.
-  $hasDeletes = $false
-  if ($recommendations -and (_Count($recommendations.Keys) -gt 0)) {
-    foreach ($k in $recommendations.Keys) {
-      if ($recommendations[$k].Recommendation -eq 'Delete') { $hasDeletes = $true; break }
+  if (-not $flagged -or $flagged.Count -eq 0) {
+    Write-Info 'AI did not flag any scripts for removal'
+    return [pscustomobject]@{
+      InventoryCount = $inventoryCount
+      Flagged        = @()
+      Removed        = @()
+      Declined       = @()
     }
   }
-  Log-Verbose ("AI recommendations summary: hasDeletes={0}, keys={1}" -f $hasDeletes, ($recommendations.Keys -join ', '))
 
-  if ($hasDeletes) {
-    $deleteCandidates = @()
-    foreach ($candidate in $allCandidates) {
-      if (-not (_HasProp $candidate 'Id')) { continue }
-      if ($recommendations.ContainsKey($candidate.Id) -and $recommendations[$candidate.Id].Recommendation -eq 'Delete') {
-        $deleteCandidates += $candidate
-      }
-    }
+  Write-Info 'AI flagged the following script paths for review:'
+  foreach ($path in $flagged) {
+    Write-Host ("  - {0}" -f $path)
+  }
 
-    if (_Count($deleteCandidates) -gt 0) {
-      Write-Host ''
-      Write-Host 'AI suggested deleting the following items:'
-      foreach ($candidate in $deleteCandidates) {
-        $reason = $recommendations[$candidate.Id].Reason
-        Write-Host ("  - {0} ({1})" -f $candidate.Id, $reason)
-      }
-      $response = Read-Host 'Proceed? (A=all, M=manual, N=skip) [A]'
-      if ([string]::IsNullOrWhiteSpace($response)) { $response = 'A' }
-      $response = $response.Trim().Substring(0,1).ToUpperInvariant()
-      if ($response -eq 'A') {
-        foreach ($candidate in $deleteCandidates) {
-          switch ($candidate.Type) { 'Task' { Remove-TaskCandidate $candidate } 'Process' { Remove-ProcessCandidate $candidate } 'Script' { Remove-ScriptCandidate $candidate } }
-          $removed.Add($candidate.Id) | Out-Null
-        }
-      } elseif ($response -eq 'M') {
-        foreach ($candidate in $deleteCandidates) {
-          $reason = $recommendations[$candidate.Id].Reason
-          $choice = Read-Host ("Remove {0}? (Reason: {1}) [Y/N]" -f $candidate.Id, $reason)
-          if ([string]::IsNullOrWhiteSpace($choice)) { $choice = 'Y' }
-          if ($choice.Trim().StartsWith('Y',[System.StringComparison]::OrdinalIgnoreCase)) {
-            switch ($candidate.Type) { 'Task' { Remove-TaskCandidate $candidate } 'Process' { Remove-ProcessCandidate $candidate } 'Script' { Remove-ScriptCandidate $candidate } }
-            $removed.Add($candidate.Id) | Out-Null
+  $removed = @()
+  $declined = @()
+
+  if ($Remove) {
+    foreach ($path in $flagged) {
+      $confirmation = Read-Host ("Remove flagged script path? (Y/N, default Y): `"$path`"")
+      if ([string]::IsNullOrWhiteSpace($confirmation)) { $confirmation = 'Y' }
+
+      if ($confirmation.Trim().StartsWith('Y', [System.StringComparison]::OrdinalIgnoreCase)) {
+        try {
+          if (Test-Path -LiteralPath $path) {
+            Write-Info ("Removing malicious script {0}" -f $path)
+            Remove-Item -LiteralPath $path -Force -ErrorAction Stop
+            $removed += $path
+          } else {
+            Write-Warn ("Flagged path not found during removal: {0}" -f $path)
           }
+        } catch {
+          Write-Warn ("Failed to remove {0}: {1}" -f $path, $_.Exception.Message)
         }
       } else {
-        Write-Info 'Skipping removal per operator request.'
+        $declined += $path
+        Write-Info ("User declined removal of {0}" -f $path)
       }
-    } else {
-      Write-Info 'No delete candidates found after parsing (unexpected).'
-    }
-  } else {
-    # No delete recommendations - offer manual review for scripts (so you still get a prompt)
-    Write-Host ''
-    Write-Host 'AI did not recommend deletions.'
-    $manual = Read-Host 'Would you like to manually review the collected scripts now? [Y/N] (Y to review files one-by-one)'
-    if (-not [string]::IsNullOrWhiteSpace($manual) -and $manual.Trim().Substring(0,1).ToUpperInvariant() -eq 'Y') {
-      foreach ($s in $scripts) {
-        $choice = Read-Host ("Quarantine script {0}? (Size={1} bytes, Modified={2}) [Y/N]" -f $s.Path, $s.Size, $s.Modified)
-        if ([string]::IsNullOrWhiteSpace($choice)) { $choice = 'N' }
-        if ($choice.Trim().StartsWith('Y',[System.StringComparison]::OrdinalIgnoreCase)) {
-          Remove-ScriptCandidate -Candidate $s
-          try { $removed.Add($s.Path) | Out-Null } catch {}
-        }
-      }
-    } else {
-      Write-Info 'Skipping manual script review.'
-    }
-  }
-
-  $accessibility = @(Get-AccessibilityStatus)
-  # Only offer restoration when there are actual issues (fixes empty-issues prompt)
-  if ($Remove) {
-    foreach ($status in $accessibility) {
-      $issues = if (_HasProp $status 'Issues') { $status.Issues } else { @() }
-      $issueCount =
-        if ($issues -is [System.Array]) { $issues.Length }
-        elseif ($issues -is [string])   { if ([string]::IsNullOrWhiteSpace($issues)) { 0 } else { 1 } }
-        else { _Count($issues) }
-      if ($issueCount -eq 0) { continue }
-
-      $issueText = (_JoinSemis $issues)
-      $choice = Read-Host ("Restore {0}? (issues: {1}) [Y/N]" -f $status.Path, $issueText)
-      if ([string]::IsNullOrWhiteSpace($choice)) { $choice = 'Y' }
-      if ($choice.Trim().StartsWith('Y',[System.StringComparison]::OrdinalIgnoreCase)) { Restore-AccessibilityBinary -Status $status | Out-Null }
     }
   }
 
   return [pscustomobject]@{
-    Tasks           = $tasks
-    Processes       = $processes
-    Scripts         = $scripts
-    Accessibility   = $accessibility
-    AiResponse      = $aiResponse
-    Recommendations = $recommendations
-    Removed         = $removed.ToArray()
+    InventoryCount = $inventoryCount
+    Flagged        = @($flagged)
+    Removed        = @($removed)
+    Declined       = @($declined)
   }
 }
 
-function Summarize-Recommendations { param($Result)
-  if (-not $Result -or (_Count($Result.Recommendations.Keys) -eq 0)) { return 'No AI guidance available.' }
-  $delete = 0; $review = 0
-  foreach ($entry in $Result.Recommendations.GetEnumerator()) {
-    switch ($entry.Value.Recommendation) { 'Delete' { $delete++ } 'Review' { $review++ } }
+function Get-ResultSummary {
+  param($Result)
+
+  if (-not $Result) { return 'Malware persistence scan completed.' }
+
+  $flaggedCount = if ($Result.Flagged) { $Result.Flagged.Count } else { 0 }
+  $removedCount = if ($Result.Removed) { $Result.Removed.Count } else { 0 }
+  $declinedCount = if ($Result.Declined) { $Result.Declined.Count } else { 0 }
+
+  $parts = @()
+  $parts += ("Flagged {0} script file(s)." -f $flaggedCount)
+  if ($removedCount -gt 0) {
+    $parts += ("Removed {0}." -f $removedCount)
+  } else {
+    $parts += 'No removals performed.'
   }
-  return ("AI flagged {0} deletion(s) and {1} review(s)." -f $delete, $review)
-}
-function Summarize-Accessibility { param($Statuses)
-  if (-not $Statuses -or (_Count($Statuses) -eq 0)) { return 'Sticky keys binaries not evaluated.' }
-  $issues = $Statuses | Where-Object { _HasProp $_ 'Issues' -and (_Count($_.Issues) -gt 0) }
-  if (-not $issues -or (_Count($issues) -eq 0)) { return 'Sticky keys binaries verified as Microsoft-signed.' }
-  $labels = $issues | ForEach-Object { "{0} ({1})" -f $_.Name, (_JoinSemis $_.Issues) }
-  return ('Sticky keys anomalies: ' + (_JoinSemis $labels))
+  if ($declinedCount -gt 0) {
+    $parts += ("User declined {0}." -f $declinedCount)
+  }
+
+  return ($parts -join ' ')
 }
 
-# ----------------- Entry Points -----------------
-function Test-Ready {
-  param($Context)
-  if (-not (Get-OpenRouterApiKey)) {
-    Write-Warn "OpenRouter API key is missing (set `$env:$($script:ApiKeyEnvVar))."
-    return $false
-  }
-  Log-Verbose "Test-Ready passed (API key present)."
-  return $true
-}
 function Invoke-Verify {
   param($Context)
+
   try {
     $result = Invoke-MalwareAssessment
   } catch {
     Write-Err ("MalwarePersistence verification failed: {0}" -f $_.Exception.Message)
     return (New-ModuleResult -Name $script:ModuleName -Status 'Failed' -Message ('Verification error: ' + $_.Exception.Message))
   }
-  $summary = Summarize-Recommendations -Result $result
-  $accessSummary = Summarize-Accessibility -Statuses $result.Accessibility
-  $message = "$summary $accessSummary".Trim()
-  if (-not $message) { $message = 'Malware persistence scan completed.' }
+
+  $message = Get-ResultSummary -Result $result
   return (New-ModuleResult -Name $script:ModuleName -Status 'Succeeded' -Message $message)
 }
+
 function Invoke-Apply {
   param($Context)
+
   try {
     $result = Invoke-MalwareAssessment -Remove
   } catch {
     Write-Err ("MalwarePersistence apply failed: {0}" -f $_.Exception.Message)
     return (New-ModuleResult -Name $script:ModuleName -Status 'Failed' -Message ('Apply error: ' + $_.Exception.Message))
   }
-  $summary = Summarize-Recommendations -Result $result
-  $removedCount = _Count($result.Removed)
-  $removedText = if ($removedCount -gt 0) { "Removed {0} item(s)." -f $removedCount } else { 'No items removed.' }
-  $accessSummary = Summarize-Accessibility -Statuses $result.Accessibility
-  $message = "$summary $removedText $accessSummary".Trim()
-  if (-not $message) { $message = 'Malware persistence remediation completed.' }
+
+  $message = Get-ResultSummary -Result $result
   return (New-ModuleResult -Name $script:ModuleName -Status 'Succeeded' -Message $message)
 }
 


### PR DESCRIPTION
## Summary
- rebuild the MalwarePersistence module to scan common persistence directories for suspicious script extensions
- send discovered script paths to OpenRouter for AI classification using the same workflow as the unwanted software module
- prompt operators to confirm each flagged path before removal when running in apply mode

## Testing
- `pwsh -NoLogo -NoProfile -Command "Import-Module (Resolve-Path modules/11_MalwarePersistence/MalwarePersistence.psm1)"` *(fails: `pwsh` not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_69054327f21c8333ad65780a675ecdde