### PR TITLE
Ensure Apache candidate selection handles single results

### DIFF
--- a/modules/04_Apache/Apache.psm1
+++ b/modules/04_Apache/Apache.psm1
@@ -58,7 +58,9 @@ function Get-HttpdCandidates {
 }
 
 function Select-HttpdPath {
-  $candidates = Get-HttpdCandidates
+  # Always treat the results as an array so we can safely rely on Count and
+  # index-based access even when only a single candidate is discovered.
+  [array]$candidates = Get-HttpdCandidates
 
   Write-Host ''
   Write-Host 'Select the Apache httpd.conf file to replace:' -ForegroundColor Cyan


### PR DESCRIPTION
## Summary
- ensure the Apache module always materializes the list of httpd.conf candidates as an array before presenting the menu

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_69054605050c8333b7d672541fcc6a17