### PR TITLE
Adjust malware persistence scanning scope and counts

### DIFF
--- a/modules/11_MalwarePersistence/MalwarePersistence.psm1
+++ b/modules/11_MalwarePersistence/MalwarePersistence.psm1
@@ -10,8 +10,8 @@ if (-not (Get-Command Write-Info -EA SilentlyContinue)) {
 $script:ModuleName       = 'MalwarePersistence'
 $script:ApiUrl           = 'https://openrouter.ai/api/v1/chat/completions'
 $script:ApiKeyEnvVar     = 'OPENROUTER_API_KEY'
-$script:ScanDirectories  = @('C:\\Users', 'C:\\ProgramData', 'C:\\Program Files', 'C:\\Program Files (x86)')
-$script:ScriptExtensions = @('.ps1','.psm1','.bat','.cmd','.vbs','.js','.jse','.hta','.py')
+$script:ScanDirectories  = @('C:\\Users', 'C:\\ProgramData')
+$script:ScriptExtensions = @('.ps1','.psm1','.bat','.cmd','.vbs','.js','.jse','.hta','.py','.zip')
 
 function Get-OpenRouterApiKey {
   $key = [System.Environment]::GetEnvironmentVariable($script:ApiKeyEnvVar)
@@ -75,11 +75,12 @@ Only mark files that are clearly malicious, suspicious persistence, or not requi
 If no files require removal, respond with [].
 "@
 
-  $inventoryBlock = ($Inventory -join [Environment]::NewLine)
+  $inventoryArray = @($Inventory)
+  $inventoryBlock = ($inventoryArray -join [Environment]::NewLine)
   $userPrompt = @"
 You are reviewing script files collected from persistence-prone directories on a Windows system.
 
-SCANNED FILES ($($Inventory.Count) entries):
+SCANNED FILES ($($inventoryArray.Count) entries):
 $inventoryBlock
 
 Identify the files that are malicious or suspicious and should be removed. Respond ONLY with a JSON array of paths.
@@ -101,11 +102,13 @@ Identify the files that are malicious or suspicious and should be removed. Respo
 function Invoke-Classification {
   param([string[]]$Inventory)
 
-  if (-not $Inventory -or $Inventory.Count -eq 0) {
+  $inventoryArray = @($Inventory)
+
+  if (-not $inventoryArray -or $inventoryArray.Count -eq 0) {
     return @()
   }
 
-  $bodyJson = Build-AiRequest -Inventory $Inventory
+  $bodyJson = Build-AiRequest -Inventory $inventoryArray
 
   $apiKey = Get-OpenRouterApiKey
   if (-not $apiKey) {
@@ -156,7 +159,8 @@ function Invoke-MalwareAssessment {
 
   Write-Info 'Enumerating potential persistence scripts'
   $inventory = Get-ScriptInventory
-  $inventoryCount = $inventory.Count
+  $inventoryArray = @($inventory)
+  $inventoryCount = $inventoryArray.Count
   Write-Info ("Collected {0} script file(s)" -f $inventoryCount)
 
   if ($inventoryCount -eq 0) {
@@ -169,9 +173,11 @@ function Invoke-MalwareAssessment {
   }
 
   Write-Info 'Requesting AI analysis from OpenRouter'
-  $flagged = Invoke-Classification -Inventory $inventory
+  $flagged = Invoke-Classification -Inventory $inventoryArray
 
-  if (-not $flagged -or $flagged.Count -eq 0) {
+  $flaggedArray = @($flagged)
+
+  if (-not $flaggedArray -or $flaggedArray.Count -eq 0) {
     Write-Info 'AI did not flag any scripts for removal'
     return [pscustomobject]@{
       InventoryCount = $inventoryCount
@@ -182,7 +188,7 @@ function Invoke-MalwareAssessment {
   }
 
   Write-Info 'AI flagged the following script paths for review:'
-  foreach ($path in $flagged) {
+  foreach ($path in $flaggedArray) {
     Write-Host ("  - {0}" -f $path)
   }
 
@@ -190,7 +196,7 @@ function Invoke-MalwareAssessment {
   $declined = @()
 
   if ($Remove) {
-    foreach ($path in $flagged) {
+    foreach ($path in $flaggedArray) {
       $confirmation = Read-Host ("Remove flagged script path? (Y/N, default Y): `"$path`"")
       if ([string]::IsNullOrWhiteSpace($confirmation)) { $confirmation = 'Y' }
 
@@ -215,7 +221,7 @@ function Invoke-MalwareAssessment {
 
   return [pscustomobject]@{
     InventoryCount = $inventoryCount
-    Flagged        = @($flagged)
+    Flagged        = @($flaggedArray)
     Removed        = @($removed)
     Declined       = @($declined)
   }
@@ -226,9 +232,13 @@ function Get-ResultSummary {
 
   if (-not $Result) { return 'Malware persistence scan completed.' }
 
-  $flaggedCount = if ($Result.Flagged) { $Result.Flagged.Count } else { 0 }
-  $removedCount = if ($Result.Removed) { $Result.Removed.Count } else { 0 }
-  $declinedCount = if ($Result.Declined) { $Result.Declined.Count } else { 0 }
+  $flaggedArray = @($Result.Flagged)
+  $removedArray = @($Result.Removed)
+  $declinedArray = @($Result.Declined)
+
+  $flaggedCount = if ($flaggedArray) { $flaggedArray.Count } else { 0 }
+  $removedCount = if ($removedArray) { $removedArray.Count } else { 0 }
+  $declinedCount = if ($declinedArray) { $declinedArray.Count } else { 0 }
 
   $parts = @()
   $parts += ("Flagged {0} script file(s)." -f $flaggedCount)


### PR DESCRIPTION
## Summary
- stop scanning Program Files directories in the malware persistence module to avoid unnecessary inventory bloat
- include zip archives in the set of script extensions evaluated for suspicious persistence
- normalize inventory handling so Count access works reliably throughout the module

## Testing
- Not run (PowerShell tooling not available in container)


------
https://chatgpt.com/codex/tasks/task_e_690546f93a648333bc71cab69a518026