### PR TITLE
Add README support for aeacus

### DIFF
--- a/core/Parsing.psm1
+++ b/core/Parsing.psm1
@@ -33,12 +33,30 @@ function Remove-HTMLTags {
 function Get-ReadmeHtmlFromUrlFile {
     [CmdletBinding()]
     param(
+        [string]$AeacusReadmePath = 'C:\aeacus\assets\ReadMe.html',
         [string[]]$Candidates = @(
             'C:\CyberPatriot\README.url',
             (Join-Path $env:PUBLIC     'Desktop\README.url'),
             (Join-Path $env:USERPROFILE 'Desktop\README.url')
         )
     )
+
+    # Check for Aeacus practice image README first
+    if (Test-Path -LiteralPath $AeacusReadmePath) {
+        Write-Info "[Readme] Found Aeacus practice image README at: $AeacusReadmePath"
+        try {
+            $htmlContent = Get-Content -LiteralPath $AeacusReadmePath -Raw -ErrorAction Stop
+            return [pscustomobject]@{
+                Url  = "file:///$AeacusReadmePath"
+                Html = $htmlContent
+            }
+        } catch {
+            Write-Warning ("Failed to read Aeacus README from {0}: {1}" -f $AeacusReadmePath, $_.Exception.Message)
+            # Fall through to CyberPatriot logic
+        }
+    }
+
+    # Fall back to CyberPatriot competition README logic
     foreach ($p in $Candidates) {
         if (-not (Test-Path -LiteralPath $p)) { continue }
         $line = Get-Content -LiteralPath $p -ErrorAction Stop |

--- a/tests/Parsing.Tests.ps1
+++ b/tests/Parsing.Tests.ps1
@@ -1,6 +1,36 @@
 $modulePath = Join-Path $PSScriptRoot '../core/Parsing.psm1'
 . $modulePath
 
+Describe 'Get-ReadmeHtmlFromUrlFile' {
+  Context 'Aeacus practice image support' {
+    It 'should check for Aeacus README first when file exists' {
+      # Create a temporary Aeacus README for testing
+      $tempAeacusPath = Join-Path $env:TEMP 'test_aeacus_readme.html'
+      $testHtml = '<html><body><h1>Test Aeacus README</h1></body></html>'
+      Set-Content -Path $tempAeacusPath -Value $testHtml -Force
+
+      try {
+        $result = Get-ReadmeHtmlFromUrlFile -AeacusReadmePath $tempAeacusPath -ErrorAction SilentlyContinue
+        $result | Should -Not -BeNullOrEmpty
+        $result.Html | Should -Be $testHtml
+        $result.Url | Should -Match 'file:///'
+      }
+      finally {
+        if (Test-Path $tempAeacusPath) {
+          Remove-Item $tempAeacusPath -Force
+        }
+      }
+    }
+
+    It 'should fall back to CyberPatriot logic when Aeacus README does not exist' {
+      $nonExistentPath = 'C:\NonExistent\Path\ReadMe.html'
+      # This should throw because no README.url files exist in test environment
+      { Get-ReadmeHtmlFromUrlFile -AeacusReadmePath $nonExistentPath -Candidates @('C:\NonExistent\README.url') } |
+        Should -Throw
+    }
+  }
+}
+
 Describe 'Find-RecentHireMentions' {
   It 'detects quoted user creation instructions' {
     $text = 'Your company just hired a new employee. Make a new account for this employee named "penguru".'


### PR DESCRIPTION
- Modified Get-ReadmeHtmlFromUrlFile to check for Aeacus README first at C:\aeacus\assets\ReadMe.html
- Falls back to CyberPatriot competition logic if Aeacus README doesn't exist
- Uses same AI parsing system for both README types
- Added comprehensive unit tests for Aeacus README functionality
- Maintains backward compatibility with existing CyberPatriot workflow