### PR TITLE
Add outbound backdoor detection to malware module

### DIFF
--- a/modules/11_MalwarePersistence/MalwarePersistence.psm1
+++ b/modules/11_MalwarePersistence/MalwarePersistence.psm1
@@ -185,6 +185,82 @@ function Get-NetworkListenerInventory {
   return @($connections)
 }
 
+function Get-OutboundConnectionInventory {
+  $connections = @()
+
+  # Legitimate processes to exclude (common browsers, updaters, Windows services)
+  $legitimateProcesses = @(
+    'chrome.exe', 'firefox.exe', 'msedge.exe', 'iexplore.exe', 'brave.exe', 'opera.exe',
+    'MicrosoftEdgeUpdate.exe', 'GoogleUpdate.exe', 'wuauclt.exe', 'UsoClient.exe', 'TrustedInstaller.exe',
+    'svchost.exe', 'OneDrive.exe', 'Teams.exe', 'Skype.exe', 'Zoom.exe', 'slack.exe',
+    'dropbox.exe', 'spotify.exe', 'discord.exe', 'steam.exe',
+    'System', 'RuntimeBroker.exe', 'SearchIndexer.exe', 'dwm.exe', 'explorer.exe',
+    'taskhostw.exe', 'taskhost.exe', 'spoolsv.exe', 'services.exe', 'csrss.exe', 'smss.exe',
+    'lsass.exe', 'wininit.exe', 'winlogon.exe', 'conhost.exe'
+  )
+
+  # Legitimate paths to exclude (system directories for Microsoft-signed binaries)
+  $legitimatePaths = @(
+    'C:\Windows\System32\',
+    'C:\Windows\SysWOW64\',
+    'C:\Windows\explorer.exe',
+    'C:\Program Files\Windows Defender\',
+    'C:\Program Files\Microsoft Office\',
+    'C:\Program Files (x86)\Microsoft\',
+    'C:\Program Files\Microsoft'
+  )
+
+  try {
+    # Get established and SynSent outbound connections
+    $outbound = Get-NetTCPConnection -State Established, SynSent -ErrorAction Stop |
+      Where-Object { $_.RemoteAddress -ne '127.0.0.1' -and $_.RemoteAddress -ne '::1' } |
+      Sort-Object OwningProcess -Unique |
+      Select-Object RemoteAddress, RemotePort, OwningProcess,
+        @{Name='ProcessName';Expression={
+            (Get-Process -Id $_.OwningProcess -ErrorAction SilentlyContinue).ProcessName
+        }},
+        @{Name='ExecutablePath';Expression={
+            (Get-CimInstance Win32_Process -Filter "ProcessId=$($_.OwningProcess)" -ErrorAction SilentlyContinue).ExecutablePath
+        }},
+        @{Name='CommandLine';Expression={
+            (Get-CimInstance Win32_Process -Filter "ProcessId=$($_.OwningProcess)" -ErrorAction SilentlyContinue).CommandLine
+        }}
+
+    foreach ($conn in $outbound) {
+      if (-not $conn.ExecutablePath) { continue }
+      if (-not $conn.ProcessName) { continue }
+
+      # Skip legitimate processes
+      $processName = $conn.ProcessName + '.exe'
+      if ($legitimateProcesses -contains $processName) { continue }
+
+      # Skip legitimate paths
+      $isLegitPath = $false
+      foreach ($legitPath in $legitimatePaths) {
+        if ($conn.ExecutablePath -like "$legitPath*") {
+          $isLegitPath = $true
+          break
+        }
+      }
+      if ($isLegitPath) { continue }
+
+      # Flag suspicious connections
+      $connections += [pscustomobject]@{
+        RemoteAddress   = $conn.RemoteAddress
+        RemotePort      = $conn.RemotePort
+        ProcessId       = $conn.OwningProcess
+        ProcessName     = $conn.ProcessName
+        ExecutablePath  = $conn.ExecutablePath
+        CommandLine     = $conn.CommandLine
+      }
+    }
+  } catch {
+    Write-Warn ("Failed to enumerate outbound connections: {0}" -f $_.Exception.Message)
+  }
+
+  return @($connections)
+}
+
 function Get-RegistryRunKeys {
   $registryPaths = @(
     # HKLM paths
@@ -886,6 +962,121 @@ function Invoke-NetworkListenerClassification {
   return @($parsed)
 }
 
+function Build-OutboundConnectionAiRequest {
+  param([array]$Connections)
+
+  $systemPrompt = @"
+You are a Windows incident response assistant for CyberPatriot scoring.
+Return ONLY a raw JSON array (no code fences) of objects identifying suspicious outbound network connections that may be reverse shells, C2 beacons, or backdoors.
+Each object should have: {"ExecutablePath": "path", "Reason": "explanation"}.
+
+CRITICAL DETECTION GUIDELINES - OUTBOUND BACKDOOR DETECTION:
+This is a second-pass scan for OUTBOUND/REVERSE backdoors (not listening servers). You're looking for:
+
+1. REVERSE SHELLS: Executables making outbound connections to non-standard ports
+   - Flag ANY executable in user directories (C:\Users\, AppData\, Downloads\, Desktop\, Documents\)
+   - Flag ANY executable in temp directories (C:\Temp\, C:\Windows\Temp\, AppData\Local\Temp\)
+   - Flag ANY executable in ProgramData or other writable locations
+   - Common indicators: cmd.exe, powershell.exe, or nc.exe connections, especially to high ports
+
+2. C2 BEACONS: Non-Microsoft signed executables making persistent connections
+   - Flag executables in suspicious locations making HTTPS (443) or HTTP (80) connections
+   - Flag executables with generic/random names connecting out
+   - Flag renamed system utilities (like nc.exe renamed to update.exe)
+
+3. SUSPICIOUS PATTERNS:
+   - Connections to unusual ports (not 80/443/53) from non-browser processes
+   - Scripts (PowerShell, Python, etc.) making network connections from user directories
+   - Executables with obfuscated or suspicious command-line arguments
+   - Connections from portable executables in writable locations
+
+4. LEGITIMATE EXCLUSIONS (already filtered, but verify):
+   - Standard browsers and their updaters (already excluded)
+   - Windows Update and Microsoft services (already excluded)
+   - Known legitimate software in Program Files (already excluded)
+
+5. IMPORTANT NOTES:
+   - This is AFTER filtering out obvious legitimate processes
+   - When executables are in user-writable locations, they're HIGHLY suspicious
+   - Non-Microsoft-signed executables making outbound connections = RED FLAG
+   - When in doubt, FLAG IT - false positives are acceptable in CyberPatriot
+
+If no connections are suspicious, respond with [].
+"@
+
+  $connectionsBlock = ($Connections | ForEach-Object {
+    "Remote: $($_.RemoteAddress):$($_.RemotePort) | PID: $($_.ProcessId) | Process: $($_.ProcessName) | Path: $($_.ExecutablePath) | CmdLine: $($_.CommandLine)"
+  }) -join [Environment]::NewLine
+
+  $userPrompt = @"
+You are reviewing OUTBOUND network connections (Established/SynSent state) on a Windows system for potential reverse shells, C2 beacons, or backdoors.
+
+IMPORTANT: These are NOT listening servers - they are outbound connections that have already bypassed basic legitimacy filters.
+
+OUTBOUND CONNECTIONS ($($Connections.Count) entries):
+$connectionsBlock
+
+Identify suspicious outbound connections that may be backdoors, reverse shells, or C2 beacons. Respond ONLY with a JSON array.
+"@
+
+  $body = @{
+    model       = 'openai/gpt-5'
+    temperature = 0
+    max_tokens  = 4000
+    messages    = @(
+      @{ role = 'system'; content = $systemPrompt },
+      @{ role = 'user'; content = $userPrompt }
+    )
+  }
+
+  return $body | ConvertTo-Json -Depth 6
+}
+
+function Invoke-OutboundConnectionClassification {
+  param([array]$Connections)
+
+  if (-not $Connections -or $Connections.Count -eq 0) {
+    return @()
+  }
+
+  $bodyJson = Build-OutboundConnectionAiRequest -Connections $Connections
+
+  $apiKey = Get-OpenRouterApiKey
+  if (-not $apiKey) {
+    throw 'OpenRouter API key was not available when classification was attempted.'
+  }
+
+  $headers = @{
+    'Authorization' = "Bearer $apiKey"
+    'Content-Type'  = 'application/json'
+  }
+
+  try {
+    $response = Invoke-RestMethod -Uri $script:ApiUrl -Method Post -Headers $headers -Body $bodyJson -ErrorAction Stop
+  } catch {
+    throw ("OpenRouter API call failed: {0}" -f $_.Exception.Message)
+  }
+
+  $content = $response.choices[0].message.content
+  if (-not $content) {
+    throw 'OpenRouter returned an empty response.'
+  }
+
+  $content = $content -replace '^```json\s*', '' -replace '\s*```$',''
+
+  try {
+    $parsed = $content | ConvertFrom-Json
+  } catch {
+    throw ("Failed to parse OpenRouter response: {0}" -f $_.Exception.Message)
+  }
+
+  if ($parsed -isnot [System.Collections.IEnumerable]) {
+    throw 'OpenRouter response was not an array.'
+  }
+
+  return @($parsed)
+}
+
 function Invoke-MalwareAssessment {
   param([switch]$Remove)
 
@@ -900,6 +1091,11 @@ function Invoke-MalwareAssessment {
   $networkConnections = Get-NetworkListenerInventory
   $networkCount = $networkConnections.Count
   Write-Info ("Collected {0} listening connection(s)" -f $networkCount)
+
+  Write-Info 'Enumerating outbound network connections'
+  $outboundConnections = Get-OutboundConnectionInventory
+  $outboundCount = $outboundConnections.Count
+  Write-Info ("Collected {0} suspicious outbound connection(s)" -f $outboundCount)
 
   Write-Info 'Enumerating registry run keys'
   $registryEntries = Get-RegistryRunKeys
@@ -922,30 +1118,34 @@ function Invoke-MalwareAssessment {
   Write-Info ("Collected {0} WMI persistence item(s)" -f $wmiCount)
 
   # Early exit if nothing found
-  if ($inventoryCount -eq 0 -and $networkCount -eq 0 -and $registryCount -eq 0 -and
+  if ($inventoryCount -eq 0 -and $networkCount -eq 0 -and $outboundCount -eq 0 -and $registryCount -eq 0 -and
       $startupCount -eq 0 -and $tasksCount -eq 0 -and $wmiCount -eq 0) {
     Write-Info 'No persistence mechanisms found'
     return [pscustomobject]@{
       InventoryCount     = 0
       NetworkCount       = 0
+      OutboundCount      = 0
       RegistryCount      = 0
       StartupCount       = 0
       TasksCount         = 0
       WmiCount           = 0
       Flagged            = @()
       FlaggedNetwork     = @()
+      FlaggedOutbound    = @()
       FlaggedRegistry    = @()
       FlaggedStartup     = @()
       FlaggedTasks       = @()
       FlaggedWmi         = @()
       Removed            = @()
       RemovedNetwork     = @()
+      RemovedOutbound    = @()
       RemovedRegistry    = @()
       RemovedStartup     = @()
       RemovedTasks       = @()
       RemovedWmi         = @()
       Declined           = @()
       DeclinedNetwork    = @()
+      DeclinedOutbound   = @()
       DeclinedRegistry   = @()
       DeclinedStartup    = @()
       DeclinedTasks      = @()
@@ -968,6 +1168,14 @@ function Invoke-MalwareAssessment {
     Write-Info 'Requesting AI analysis for network connections from OpenRouter'
     $flaggedNetwork = Invoke-NetworkListenerClassification -Connections $networkConnections
     $flaggedNetworkArray = @($flaggedNetwork)
+  }
+
+  # Process outbound connections
+  $flaggedOutboundArray = @()
+  if ($outboundCount -gt 0) {
+    Write-Info 'Requesting AI analysis for outbound connections from OpenRouter'
+    $flaggedOutbound = Invoke-OutboundConnectionClassification -Connections $outboundConnections
+    $flaggedOutboundArray = @($flaggedOutbound)
   }
 
   # Process registry entries
@@ -1003,7 +1211,7 @@ function Invoke-MalwareAssessment {
   }
 
   # Check if anything was flagged
-  $totalFlagged = $flaggedArray.Count + $flaggedNetworkArray.Count + $flaggedRegistryArray.Count +
+  $totalFlagged = $flaggedArray.Count + $flaggedNetworkArray.Count + $flaggedOutboundArray.Count + $flaggedRegistryArray.Count +
                   $flaggedStartupArray.Count + $flaggedTasksArray.Count + $flaggedWmiArray.Count
 
   if ($totalFlagged -eq 0) {
@@ -1011,24 +1219,28 @@ function Invoke-MalwareAssessment {
     return [pscustomobject]@{
       InventoryCount     = $inventoryCount
       NetworkCount       = $networkCount
+      OutboundCount      = $outboundCount
       RegistryCount      = $registryCount
       StartupCount       = $startupCount
       TasksCount         = $tasksCount
       WmiCount           = $wmiCount
       Flagged            = @()
       FlaggedNetwork     = @()
+      FlaggedOutbound    = @()
       FlaggedRegistry    = @()
       FlaggedStartup     = @()
       FlaggedTasks       = @()
       FlaggedWmi         = @()
       Removed            = @()
       RemovedNetwork     = @()
+      RemovedOutbound    = @()
       RemovedRegistry    = @()
       RemovedStartup     = @()
       RemovedTasks       = @()
       RemovedWmi         = @()
       Declined           = @()
       DeclinedNetwork    = @()
+      DeclinedOutbound   = @()
       DeclinedRegistry   = @()
       DeclinedStartup    = @()
       DeclinedTasks      = @()
@@ -1049,6 +1261,14 @@ function Invoke-MalwareAssessment {
   if ($flaggedNetworkArray.Count -gt 0) {
     Write-Info 'AI flagged the following network connections as suspicious:'
     foreach ($item in $flaggedNetworkArray) {
+      Write-Host ("  - {0} (Reason: {1})" -f $item.ExecutablePath, $item.Reason)
+    }
+  }
+
+  # Display flagged outbound connections
+  if ($flaggedOutboundArray.Count -gt 0) {
+    Write-Info 'AI flagged the following outbound connections as suspicious:'
+    foreach ($item in $flaggedOutboundArray) {
       Write-Host ("  - {0} (Reason: {1})" -f $item.ExecutablePath, $item.Reason)
     }
   }
@@ -1092,6 +1312,8 @@ function Invoke-MalwareAssessment {
   $declined = @()
   $removedNetwork = @()
   $declinedNetwork = @()
+  $removedOutbound = @()
+  $declinedOutbound = @()
   $removedRegistry = @()
   $declinedRegistry = @()
   $removedStartup = @()
@@ -1155,6 +1377,40 @@ function Invoke-MalwareAssessment {
         }
       } else {
         $declinedNetwork += $path
+        Write-Info ("User declined removal of {0}" -f $path)
+      }
+    }
+
+    # Handle outbound connection removals
+    foreach ($item in $flaggedOutboundArray) {
+      $path = $item.ExecutablePath
+      $reason = $item.Reason
+      $confirmation = Read-Host ("Remove suspicious outbound connection? (Y/N, default Y): `"$path`" - $reason")
+      if ([string]::IsNullOrWhiteSpace($confirmation)) { $confirmation = 'Y' }
+
+      if ($confirmation.Trim().StartsWith('Y', [System.StringComparison]::OrdinalIgnoreCase)) {
+        try {
+          if (Test-Path -LiteralPath $path) {
+            Write-Info ("Removing suspicious outbound connection executable {0}" -f $path)
+            $processes = Get-Process | Where-Object { $_.Path -eq $path } -ErrorAction SilentlyContinue
+            foreach ($proc in $processes) {
+              try {
+                Write-Info ("Stopping process {0} (PID: {1})" -f $proc.Name, $proc.Id)
+                Stop-Process -Id $proc.Id -Force -ErrorAction Stop
+              } catch {
+                Write-Warn ("Failed to stop process {0}: {1}" -f $proc.Id, $_.Exception.Message)
+              }
+            }
+            Remove-Item -LiteralPath $path -Force -ErrorAction Stop
+            $removedOutbound += $path
+          } else {
+            Write-Warn ("Flagged path not found during removal: {0}" -f $path)
+          }
+        } catch {
+          Write-Warn ("Failed to remove {0}: {1}" -f $path, $_.Exception.Message)
+        }
+      } else {
+        $declinedOutbound += $path
         Write-Info ("User declined removal of {0}" -f $path)
       }
     }
@@ -1279,24 +1535,28 @@ function Invoke-MalwareAssessment {
   return [pscustomobject]@{
     InventoryCount     = $inventoryCount
     NetworkCount       = $networkCount
+    OutboundCount      = $outboundCount
     RegistryCount      = $registryCount
     StartupCount       = $startupCount
     TasksCount         = $tasksCount
     WmiCount           = $wmiCount
     Flagged            = @($flaggedArray)
     FlaggedNetwork     = @($flaggedNetworkArray)
+    FlaggedOutbound    = @($flaggedOutboundArray)
     FlaggedRegistry    = @($flaggedRegistryArray)
     FlaggedStartup     = @($flaggedStartupArray)
     FlaggedTasks       = @($flaggedTasksArray)
     FlaggedWmi         = @($flaggedWmiArray)
     Removed            = @($removed)
     RemovedNetwork     = @($removedNetwork)
+    RemovedOutbound    = @($removedOutbound)
     RemovedRegistry    = @($removedRegistry)
     RemovedStartup     = @($removedStartup)
     RemovedTasks       = @($removedTasks)
     RemovedWmi         = @($removedWmi)
     Declined           = @($declined)
     DeclinedNetwork    = @($declinedNetwork)
+    DeclinedOutbound   = @($declinedOutbound)
     DeclinedRegistry   = @($declinedRegistry)
     DeclinedStartup    = @($declinedStartup)
     DeclinedTasks      = @($declinedTasks)
@@ -1316,6 +1576,9 @@ function Get-ResultSummary {
   $flaggedNetworkArray = @($Result.FlaggedNetwork)
   $removedNetworkArray = @($Result.RemovedNetwork)
   $declinedNetworkArray = @($Result.DeclinedNetwork)
+  $flaggedOutboundArray = @($Result.FlaggedOutbound)
+  $removedOutboundArray = @($Result.RemovedOutbound)
+  $declinedOutboundArray = @($Result.DeclinedOutbound)
   $flaggedRegistryArray = @($Result.FlaggedRegistry)
   $removedRegistryArray = @($Result.RemovedRegistry)
   $declinedRegistryArray = @($Result.DeclinedRegistry)
@@ -1336,6 +1599,9 @@ function Get-ResultSummary {
   $flaggedNetworkCount = if ($flaggedNetworkArray) { $flaggedNetworkArray.Count } else { 0 }
   $removedNetworkCount = if ($removedNetworkArray) { $removedNetworkArray.Count } else { 0 }
   $declinedNetworkCount = if ($declinedNetworkArray) { $declinedNetworkArray.Count } else { 0 }
+  $flaggedOutboundCount = if ($flaggedOutboundArray) { $flaggedOutboundArray.Count } else { 0 }
+  $removedOutboundCount = if ($removedOutboundArray) { $removedOutboundArray.Count } else { 0 }
+  $declinedOutboundCount = if ($declinedOutboundArray) { $declinedOutboundArray.Count } else { 0 }
   $flaggedRegistryCount = if ($flaggedRegistryArray) { $flaggedRegistryArray.Count } else { 0 }
   $removedRegistryCount = if ($removedRegistryArray) { $removedRegistryArray.Count } else { 0 }
   $declinedRegistryCount = if ($declinedRegistryArray) { $declinedRegistryArray.Count } else { 0 }
@@ -1350,11 +1616,11 @@ function Get-ResultSummary {
   $declinedWmiCount = if ($declinedWmiArray) { $declinedWmiArray.Count } else { 0 }
 
   # Calculate totals
-  $totalFlagged = $flaggedCount + $flaggedNetworkCount + $flaggedRegistryCount +
+  $totalFlagged = $flaggedCount + $flaggedNetworkCount + $flaggedOutboundCount + $flaggedRegistryCount +
                   $flaggedStartupCount + $flaggedTasksCount + $flaggedWmiCount
-  $totalRemoved = $removedCount + $removedNetworkCount + $removedRegistryCount +
+  $totalRemoved = $removedCount + $removedNetworkCount + $removedOutboundCount + $removedRegistryCount +
                   $removedStartupCount + $removedTasksCount + $removedWmiCount
-  $totalDeclined = $declinedCount + $declinedNetworkCount + $declinedRegistryCount +
+  $totalDeclined = $declinedCount + $declinedNetworkCount + $declinedOutboundCount + $declinedRegistryCount +
                    $declinedStartupCount + $declinedTasksCount + $declinedWmiCount
 
   # Build summary message
@@ -1364,6 +1630,7 @@ function Get-ResultSummary {
   $flaggedDetails = @()
   if ($flaggedCount -gt 0) { $flaggedDetails += "$flaggedCount script(s)" }
   if ($flaggedNetworkCount -gt 0) { $flaggedDetails += "$flaggedNetworkCount listener(s)" }
+  if ($flaggedOutboundCount -gt 0) { $flaggedDetails += "$flaggedOutboundCount outbound connection(s)" }
   if ($flaggedRegistryCount -gt 0) { $flaggedDetails += "$flaggedRegistryCount registry key(s)" }
   if ($flaggedStartupCount -gt 0) { $flaggedDetails += "$flaggedStartupCount startup item(s)" }
   if ($flaggedTasksCount -gt 0) { $flaggedDetails += "$flaggedTasksCount task(s)" }
@@ -1380,6 +1647,7 @@ function Get-ResultSummary {
     $removedDetails = @()
     if ($removedCount -gt 0) { $removedDetails += "$removedCount script(s)" }
     if ($removedNetworkCount -gt 0) { $removedDetails += "$removedNetworkCount listener(s)" }
+    if ($removedOutboundCount -gt 0) { $removedDetails += "$removedOutboundCount outbound connection(s)" }
     if ($removedRegistryCount -gt 0) { $removedDetails += "$removedRegistryCount registry key(s)" }
     if ($removedStartupCount -gt 0) { $removedDetails += "$removedStartupCount startup item(s)" }
     if ($removedTasksCount -gt 0) { $removedDetails += "$removedTasksCount task(s)" }
@@ -1394,6 +1662,7 @@ function Get-ResultSummary {
     $declinedDetails = @()
     if ($declinedCount -gt 0) { $declinedDetails += "$declinedCount script(s)" }
     if ($declinedNetworkCount -gt 0) { $declinedDetails += "$declinedNetworkCount listener(s)" }
+    if ($declinedOutboundCount -gt 0) { $declinedDetails += "$declinedOutboundCount outbound connection(s)" }
     if ($declinedRegistryCount -gt 0) { $declinedDetails += "$declinedRegistryCount registry key(s)" }
     if ($declinedStartupCount -gt 0) { $declinedDetails += "$declinedStartupCount startup item(s)" }
     if ($declinedTasksCount -gt 0) { $declinedDetails += "$declinedTasksCount task(s)" }


### PR DESCRIPTION
Expands malware detection to catch reverse shells, C2 beacons, and other non-listening backdoors that the current listener-only detection misses.

Key changes:
- Added Get-OutboundConnectionInventory() to detect Established/SynSent TCP connections from suspicious executables
- Implemented filtering to exclude legitimate processes (browsers, Windows update, common applications)
- Added Build-OutboundConnectionAiRequest() and Invoke-OutboundConnectionClassification() for LLM-based analysis
- Integrated outbound detection into main assessment flow with collection, classification, display, and removal phases
- Updated result objects and summary reporting to include outbound connection data

Detection targets:
- Reverse shells (nc -e connecting to attackers)
- C2 beacons making outbound HTTPS/TCP connections
- Executables in user-writable locations making network connections
- Non-Microsoft-signed binaries with suspicious outbound traffic
- Renamed system utilities used as backdoors

This addresses the gap where State=Listen filtering missed outbound-only malware, providing comprehensive network-based backdoor detection.